### PR TITLE
Consistently use `safeTransfer`

### DIFF
--- a/src/UniV4Donations.sol
+++ b/src/UniV4Donations.sol
@@ -85,6 +85,8 @@ contract UniV4Donations is BribeInitiative, BaseHook {
     }
 
     function _donateToPool() internal returns (uint256) {
+        /// @audit TODO: Need to use storage value here I think
+        /// TODO: Test and fix release speed, which looks off
         Vesting memory _vesting = _restartVesting(uint240(governance.claimForInitiative(address(this))));
         uint256 amount =
             (_vesting.amount * (block.timestamp - vestingEpochStart()) / VESTING_EPOCH_DURATION) - _vesting.released;

--- a/src/UserProxy.sol
+++ b/src/UserProxy.sol
@@ -36,7 +36,7 @@ contract UserProxy is IUserProxy {
 
     /// @inheritdoc IUserProxy
     function stake(uint256 _amount, address _lqtyFrom) public onlyStakingV2 {
-        lqty.transferFrom(_lqtyFrom, address(this), _amount);
+        lqty.safeTransferFrom(_lqtyFrom, address(this), _amount);
         lqty.approve(address(stakingV1), _amount);
         stakingV1.stake(_amount);
         emit Stake(_amount, _lqtyFrom);


### PR DESCRIPTION
TODO: Maybe we just remove `safe*` since we don't need it?