### PR TITLE
Feat simplify `onAfterAllocateLQTY` hook

### DIFF
--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -157,6 +157,8 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
 
         if (_currentEpoch == 0) return;
 
+        assert(_voteLQTY == 0 || _vetoLQTY == 0); // Key invariant: Either Voting or Vetoing for a specific initiative
+
         // if this is the first user allocation in the epoch, then insert a new item into the user allocation DLL
         if (mostRecentUserEpoch != _currentEpoch) {
             uint88 prevVoteLQTY = lqtyAllocationByUserAtEpoch[_user].items[mostRecentUserEpoch].value;

--- a/src/UniV4Donations.sol
+++ b/src/UniV4Donations.sol
@@ -85,6 +85,8 @@ contract UniV4Donations is BribeInitiative, BaseHook {
     }
 
     function _donateToPool() internal returns (uint256) {
+        /// @audit TODO: Need to use storage value here I think
+        /// TODO: Test and fix release speed, which looks off
         Vesting memory _vesting = _restartVesting(uint240(governance.claimForInitiative(address(this))));
         uint256 amount =
             (_vesting.amount * (block.timestamp - vestingEpochStart()) / VESTING_EPOCH_DURATION) - _vesting.released;

--- a/test/BribeInitiativeAllocate.t.sol
+++ b/test/BribeInitiativeAllocate.t.sol
@@ -120,11 +120,11 @@ contract BribeInitiativeAllocateTest is Test {
 
         vm.startPrank(address(governance));
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, 1e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, 1e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 0);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user2, governance.epoch()), 0);
 
@@ -154,7 +154,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
         governance.setEpoch(2);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -196,12 +196,12 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
         governance.setEpoch(2);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
         governance.setEpoch(3);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
     }
@@ -259,7 +259,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -294,7 +294,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -326,11 +326,11 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 1000e18, 1);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 1000e18, 0);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
     }

--- a/test/BribeInitiativeAllocate.t.sol
+++ b/test/BribeInitiativeAllocate.t.sol
@@ -103,7 +103,7 @@ contract BribeInitiativeAllocateTest is Test {
         vm.startPrank(address(governance));
 
         bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, 1e18, 0);
-        assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
+        assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18, "initial LQTY");
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user2, governance.epoch()), 1e18);
 
         bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 1000e18, 0);
@@ -120,11 +120,11 @@ contract BribeInitiativeAllocateTest is Test {
 
         vm.startPrank(address(governance));
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, 1e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 0);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user2, governance.epoch()), 0);
 
@@ -154,7 +154,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
         governance.setEpoch(2);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -196,12 +196,12 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
         governance.setEpoch(2);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
         governance.setEpoch(3);
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
     }
@@ -259,7 +259,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -294,7 +294,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
@@ -326,11 +326,11 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1001e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 1000e18);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 2000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
 
-        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 1000e18, 0);
+        bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user, 0, 1);
         assertEq(bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch()), 1e18);
         assertEq(bribeInitiative.lqtyAllocatedByUserAtEpoch(user, governance.epoch()), 0);
     }


### PR DESCRIPTION
- [x] Add `assert` for `onAfterAllocateLQTY` to ensure the code works as the spec
- [x] Rewrite the code to be easier to read
- [x] Simplify the code
- [X] Implement tests for it
- [ ] E2E / Fuzz for reverts
- [ ] Invariant Tests for accounting and reverts

- [x] Fix Tests
These tests are currently broken:
```solidity
Ran 8 test suites in 2.22s (2.21s CPU time): 37 tests passed, 6 failed, 0 skipped (43 total tests)

Failing tests:
Encountered 6 failing tests in test/BribeInitiativeAllocate.t.sol:BribeInitiativeAllocateTest
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_newEpoch_NoVetoToVeto() (gas: 403990)
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_newEpoch_VetoToNoVeto() (gas: 252067)
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_newEpoch_VetoToVeto() (gas: 252110)
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_sameEpoch_NoVetoToVeto() (gas: 355481)
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_sameEpoch_VetoToNoVeto() (gas: 355460)
[FAIL. Reason: assertion failed: 2001000000000000000000 != 1000000000000000000] test_onAfterAllocateLQTY_sameEpoch_VetoToVeto() (gas: 204028)
```

I believe they were implemented incorrectly as they were allowing one caller to both vote and veto, but I wanted to make sure.

CC: @jltqy  @ColinPlatt 