### PR TITLE
EXP - Rational Flow for Bribes and Claims

### DIFF
--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -58,7 +58,7 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
     function depositBribe(uint128 _boldAmount, uint128 _bribeTokenAmount, uint16 _epoch) external {
 
         uint16 epoch = governance.epoch();
-        require(_epoch > epoch, "BribeInitiative: only-future-epochs");
+        require(_epoch >= epoch, "BribeInitiative: only-future-epochs");
 
         Bribe memory bribe = bribeByEpoch[_epoch];
         bribe.boldAmount += _boldAmount;

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -77,7 +77,7 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         uint16 _prevLQTYAllocationEpoch,
         uint16 _prevTotalLQTYAllocationEpoch
     ) internal returns (uint256 boldAmount, uint256 bribeTokenAmount) {
-        require(_epoch != governance.epoch(), "BribeInitiative: cannot-claim-for-current-epoch");
+        require(_epoch < governance.epoch(), "BribeInitiative: cannot-claim-for-current-epoch");
         require(!claimedBribeAtEpoch[_user][_epoch], "BribeInitiative: already-claimed");
 
         Bribe memory bribe = bribeByEpoch[_epoch];

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -56,8 +56,6 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
 
     /// @inheritdoc IBribeInitiative
     function depositBribe(uint128 _boldAmount, uint128 _bribeTokenAmount, uint16 _epoch) external {
-        bold.safeTransferFrom(msg.sender, address(this), _boldAmount);
-        bribeToken.safeTransferFrom(msg.sender, address(this), _bribeTokenAmount);
 
         uint16 epoch = governance.epoch();
         require(_epoch > epoch, "BribeInitiative: only-future-epochs");
@@ -68,6 +66,9 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         bribeByEpoch[_epoch] = bribe;
 
         emit DepositBribe(msg.sender, _boldAmount, _bribeTokenAmount, _epoch);
+
+        bold.safeTransferFrom(msg.sender, address(this), _boldAmount);
+        bribeToken.safeTransferFrom(msg.sender, address(this), _bribeTokenAmount);
     }
 
     function _claimBribe(


### PR DESCRIPTION
Changes the `BribeInitiative` code to:
- [x] Allow adding bribes for the current epoch
- [x] Allowing claiming bribes up to the previous epoch
- [x] Enforce a check that allows claiming exclusively for epochs in the past