### PR TITLE
Optional Fix: Future lookup

### DIFF
--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -175,10 +175,12 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
     }
 
     function _loadTotalLQTYAllocation(uint16 _epoch) private view returns (uint88, uint32) {
+        require(_epoch <= governance.epoch(), "No future Lookup");
         return _decodeLQTYAllocation(totalLQTYAllocationByEpoch.items[_epoch].value);
     }
 
     function _loadLQTYAllocation(address _user, uint16 _epoch) private view returns (uint88, uint32) {
+        require(_epoch <= governance.epoch(), "No future Lookup");
         return _decodeLQTYAllocation(lqtyAllocationByUserAtEpoch[_user].items[_epoch].value);
     }
 

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {Test} from "forge-std/Test.sol";
 import {TargetFunctions} from "./TargetFunctions.sol";
 import {FoundryAsserts} from "@chimera/FoundryAsserts.sol";
+import {IBribeInitiative} from "src/interfaces/IBribeInitiative.sol";
 
 import {console} from "forge-std/console.sol";
 
@@ -33,6 +34,41 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         vm.warp(block.timestamp + 606998);
         governance_allocateLQTY_clamped_single_initiative(0,0,1);
         property_BI04();
+    }
+
+    // forge test --match-test test_property_BI04_0 -vv 
+    function test_property_BI04_0() public {
+
+            governance_depositLQTY(2);
+
+            vm.roll(block.number + 1);
+            vm.warp(block.timestamp + 794178);
+            check_skip_consistecy(0);
+
+            IBribeInitiative initiative = IBribeInitiative(_getDeployedInitiative(0));
+
+            (uint88 totalLQTYAllocatedAtEpochPrev, ) = initiative.totalLQTYAllocatedByEpoch(governance.epoch());
+            vm.roll(block.number + 1);
+            vm.warp(block.timestamp + 1022610);
+            
+            governance_allocateLQTY_clamped_single_initiative(0,1,0);
+
+            (uint88 totalLQTYAllocatedAtEpoch, ) = initiative.totalLQTYAllocatedByEpoch(governance.epoch());
+            (
+                uint88 voteLQTY,
+                ,
+                ,
+                ,
+                
+            ) = governance.initiativeStates(_getDeployedInitiative(0));
+
+            check_unregisterable_consistecy(0);
+
+            console.log("totalLQTYAllocatedAtEpochPrev", totalLQTYAllocatedAtEpochPrev);
+            console.log("totalLQTYAllocatedAtEpoch", totalLQTYAllocatedAtEpoch);
+            console.log("voteLQTY", voteLQTY);
+
+            property_BI04();
     }
 
     // forge test --match-test test_property_BI11_3 -vv 

--- a/test/recon/properties/BribeInitiativeProperties.sol
+++ b/test/recon/properties/BribeInitiativeProperties.sol
@@ -67,8 +67,8 @@ function property_BI04() public {
         for(uint8 i; i < deployedInitiatives.length; i++) {
             IBribeInitiative initiative = IBribeInitiative(deployedInitiatives[i]);
 
-            // NOTE: This can revert if no changes happen in an epoch | That's ok
-            (uint88 totalLQTYAllocatedAtEpoch, ) = initiative.totalLQTYAllocatedByEpoch(currentEpoch);
+            // NOTE: This doesn't revert in the future!
+            uint88 lastKnownLQTYAlloc = _getLastLQTYAllocationKnown(initiative, currentEpoch);
 
             // We compare when we don't get a revert (a change happened this epoch)
 
@@ -82,8 +82,21 @@ function property_BI04() public {
 
             
 
-            eq(totalLQTYAllocatedAtEpoch, voteLQTY, "BI-04: Initiative Account matches governace");
+            eq(lastKnownLQTYAlloc, voteLQTY, "BI-04: Initiative Account matches governace");
         }
+    }
+
+    function _getLastLQTYAllocationKnown(IBribeInitiative initiative, uint16 targetEpoch) internal returns (uint88) {
+        uint16 currenEpoch;
+        uint88 found;
+        while(currenEpoch <= targetEpoch) {
+            (uint88 totalLQTYAllocatedAtEpoch, uint32 ts) = initiative.totalLQTYAllocatedByEpoch(currenEpoch++);
+            if(ts != 0) {
+                found = totalLQTYAllocatedAtEpoch;
+            }
+        }
+
+        return found;
     }
 
     function property_BI05() public {


### PR DESCRIPTION
Personally I was under the assumption that looking past the epoch boundary would cause a revert
That is not the case

This PR addresses this issue

- [x] Prevent looking for balances past the current epoch


It's worth double checking if there's any parameter beside the correct one that allows claiming bribes