### PR TITLE
Optional Fix -  cap bribes mismatch

### DIFF
--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -130,8 +130,23 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
             bribeTokenAmount += bribeTokenAmount_;
         }
 
-        if (boldAmount != 0) bold.safeTransfer(msg.sender, boldAmount);
-        if (bribeTokenAmount != 0) bribeToken.safeTransfer(msg.sender, bribeTokenAmount);
+        if (boldAmount != 0) {
+            uint256 max = bold.balanceOf(address(this));
+            if(boldAmount > max) {
+                boldAmount = max;
+            }
+            bold.safeTransfer(msg.sender, boldAmount);
+        }
+        if (bribeTokenAmount != 0) {
+            uint256 max = bribeToken.balanceOf(address(this));
+            if(bribeTokenAmount > max) {
+                bribeTokenAmount = max;
+            }
+            bribeToken.safeTransfer(msg.sender, bribeTokenAmount);
+        }
+            
+        
+        
     }
 
     /// @inheritdoc IInitiative


### PR DESCRIPTION
There's a rounding error in how `averageTimestamp` is computed

This allows people to grief other claimers  see `test_high_deny_last_claim`:
https://github.com/liquity/V2-gov/blob/cf83655f285d617fd05c65d0437c6a0558126979/test/BribeInitiative.t.sol#L317-L348

This fix prevent the grief

The math is still incorrect and imo should be fixed