### PR TITLE
Dev fix properties

### DIFF
--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -13,7 +13,7 @@ import {UserProxy} from "./UserProxy.sol";
 import {UserProxyFactory} from "./UserProxyFactory.sol";
 
 import {add, max} from "./utils/Math.sol";
-import {_requireNoDuplicates} from "./utils/UniqueArray.sol";
+import {_requireNoDuplicates, _requireNoNegatives} from "./utils/UniqueArray.sol";
 import {Multicall} from "./utils/Multicall.sol";
 import {WAD, PermitParams} from "./utils/Types.sol";
 import {safeCallWithMinGas} from "./utils/SafeCallMinGas.sol";
@@ -564,7 +564,9 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
         _requireNoDuplicates(_initiatives);
         _requireNoDuplicates(_initiativesToReset);
 
-        // TODO: Add explicit negative values checks
+        // Explicit >= 0 checks for all values since we reset values below
+        _requireNoNegatives(_absoluteLQTYVotes);
+        _requireNoNegatives(_absoluteLQTYVetos);
 
         // You MUST always reset
         ResetInitiativeData[] memory cachedData = _resetInitiatives(_initiativesToReset);

--- a/src/utils/UniqueArray.sol
+++ b/src/utils/UniqueArray.sol
@@ -20,3 +20,12 @@ function _requireNoDuplicates(address[] memory arr) pure {
         }
     }
 }
+
+function _requireNoNegatives(int88[] memory vals) pure {
+    uint256 arrLength = vals.length;
+
+    for (uint i; i < arrLength; i++) {
+        require(vals[i] >= 0, "Cannot be negative");
+        
+    }
+}

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -764,7 +764,7 @@ contract GovernanceTest is Test {
 
         removeDeltaLQTYVotes[0] = -1e18;
 
-        vm.expectRevert();
+        vm.expectRevert("Cannot be negative");
         governance.allocateLQTY(removeInitiatives, removeInitiatives, removeDeltaLQTYVotes, removeDeltaLQTYVetos);
 
         address[] memory reAddInitiatives = new address[](1);
@@ -997,7 +997,6 @@ contract GovernanceTest is Test {
         removeInitiatives[0] = baseInitiative1;
         removeInitiatives[1] = baseInitiative2;
         int88[] memory removeDeltaLQTYVotes = new int88[](2);
-        // removeDeltaLQTYVotes[0] = int88(-1e18); // @audit deallocating is no longer possible
         removeDeltaLQTYVotes[0] = 0;
         int88[] memory removeDeltaLQTYVetos = new int88[](2);
 

--- a/test/recon/Setup.sol
+++ b/test/recon/Setup.sol
@@ -28,8 +28,7 @@ abstract contract Setup is BaseSetup {
     bool internal claimedTwice;
     bool internal unableToClaim;
 
-    mapping(uint16 => uint88) internal ghostTotalAllocationAtEpoch;
-    mapping(address => uint88) internal ghostLqtyAllocationByUserAtEpoch;
+
     // initiative => epoch => bribe
     mapping(address => mapping(uint16 => IBribeInitiative.Bribe)) internal ghostBribeByEpoch;
 

--- a/test/recon/properties/GovernanceProperties.sol
+++ b/test/recon/properties/GovernanceProperties.sol
@@ -92,11 +92,12 @@ abstract contract GovernanceProperties is BeforeAfter {
 
     // Function sound total math
 
-    // NOTE: Global vs USer vs Initiative requires changes
+    // NOTE: Global vs Uer vs Initiative requires changes
     // User is tracking votes and vetos together
     // Whereas Votes and Initiatives only track Votes
     /// The Sum of LQTY allocated by Users matches the global state
     // NOTE: Sum of positive votes
+    // Remove the initiative from Unregistered Initiatives
     function property_sum_of_lqty_global_user_matches() public {
         // Get state
         // Get all users
@@ -116,6 +117,8 @@ abstract contract GovernanceProperties is BeforeAfter {
 
         eq(totalCountedLQTY, totalUserCountedLQTY, "Global vs SUM(Users_lqty) must match");
     }
+
+
 
     // NOTE: In principle this will work since this is a easier to reach property vs checking each initiative
     function property_ensure_user_alloc_cannot_dos() public {

--- a/test/recon/targets/BribeInitiativeTargets.sol
+++ b/test/recon/targets/BribeInitiativeTargets.sol
@@ -5,9 +5,9 @@ import {Test} from "forge-std/Test.sol";
 import {BaseTargetFunctions} from "@chimera/BaseTargetFunctions.sol";
 import {vm} from "@chimera/Hevm.sol";
 
-import {IInitiative} from "../../../src/interfaces/IInitiative.sol";
-import {IBribeInitiative} from "../../../src/interfaces/IBribeInitiative.sol";
-import {DoubleLinkedList} from "../../../src/utils/DoubleLinkedList.sol";
+import {IInitiative} from "src/interfaces/IInitiative.sol";
+import {IBribeInitiative} from "src/interfaces/IBribeInitiative.sol";
+import {DoubleLinkedList} from "src/utils/DoubleLinkedList.sol";
 import {Properties} from "../Properties.sol";
 
 abstract contract BribeInitiativeTargets is Test, BaseTargetFunctions, Properties {


### PR DESCRIPTION
- [x] Unit test for Total Allocated LQTY when removing from `DISABLED` property
- [x] Invariant test for Total Allocated LQTY when removing from `DISABLED` property
- [x] Fix of accounting error
- [x] Explicit check for non negative inputs in `allocateLQTY`

## Invariant Changes
- [x] More explicit, inductive based testing for all accounting math
- [x] For each user allocation, account for the power they are using, add a check to ensure that removing is idempotent, even if they changed their user state - Implemented in `exp-reset-all`