### PR TITLE
Fix no casting lqty to votes

### DIFF
--- a/ToFix.MD
+++ b/ToFix.MD
@@ -21,9 +21,32 @@ Because that's key
 
 - From there, reason around the deeper rounding errors
 
-
+---------
 
 Optimizations
 Put the data in the storage
 Remove all castings that are not safe
 Invariant test it
+
+---------
+
+TODO: Most likely need to review this
+https://github.com/liquity/V2-gov/blob/81f3e55ab9c145cf185d1aeb2417f03807a4caf3/src/BribeInitiative.sol#L129-L142
+
+```solidity
+if (boldAmount != 0) {
+            uint256 max = bold.balanceOf(address(this));
+            if (boldAmount > max) {
+                boldAmount = max;
+            }
+            bold.safeTransfer(msg.sender, boldAmount);
+        }
+        if (bribeTokenAmount != 0) {
+            uint256 max = bribeToken.balanceOf(address(this));
+            if (bribeTokenAmount > max) {
+                bribeTokenAmount = max;
+            }
+            bribeToken.safeTransfer(msg.sender, bribeTokenAmount);
+        }
+```
+And find revert cases

--- a/ToFix.MD
+++ b/ToFix.MD
@@ -1,3 +1,4 @@
+
 - Add properties check to ensure that the math is sound <- HUGE, let's add it now
 
 A vote is: User TS * Votes

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -99,10 +99,10 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         );
 
         (uint88 totalLQTY, uint32 totalAverageTimestamp) = _decodeLQTYAllocation(totalLQTYAllocation.value);
-        uint240 totalVotes = governance.lqtyToVotes(totalLQTY, block.timestamp, totalAverageTimestamp);
+        uint240 totalVotes = governance.lqtyToVotes(totalLQTY, uint32(block.timestamp), totalAverageTimestamp);
         if (totalVotes != 0) {
             (uint88 lqty, uint32 averageTimestamp) = _decodeLQTYAllocation(lqtyAllocation.value);
-            uint240 votes = governance.lqtyToVotes(lqty, block.timestamp, averageTimestamp);
+            uint240 votes = governance.lqtyToVotes(lqty, uint32(block.timestamp), averageTimestamp);
             boldAmount = uint256(bribe.boldAmount) * uint256(votes) / uint256(totalVotes);
             bribeTokenAmount = uint256(bribe.bribeTokenAmount) * uint256(votes) / uint256(totalVotes);
         }

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -99,10 +99,10 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         );
 
         (uint88 totalLQTY, uint32 totalAverageTimestamp) = _decodeLQTYAllocation(totalLQTYAllocation.value);
-        uint240 totalVotes = governance.lqtyToVotes(totalLQTY, uint32(block.timestamp), totalAverageTimestamp);
+        uint120 totalVotes = governance.lqtyToVotes(totalLQTY, uint32(block.timestamp), totalAverageTimestamp);
         if (totalVotes != 0) {
             (uint88 lqty, uint32 averageTimestamp) = _decodeLQTYAllocation(lqtyAllocation.value);
-            uint240 votes = governance.lqtyToVotes(lqty, uint32(block.timestamp), averageTimestamp);
+            uint120 votes = governance.lqtyToVotes(lqty, uint32(block.timestamp), averageTimestamp);
             boldAmount = uint256(bribe.boldAmount) * uint256(votes) / uint256(totalVotes);
             bribeTokenAmount = uint256(bribe.bribeTokenAmount) * uint256(votes) / uint256(totalVotes);
         }

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -357,12 +357,12 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
             shouldUpdate = true;
 
             uint32 start = epochStart();
-            uint240 votes =
+            uint120 votes =
                 lqtyToVotes(initiativeState.voteLQTY, start, initiativeState.averageStakingTimestampVoteLQTY);
-            uint240 vetos =
+            uint120 vetos =
                 lqtyToVotes(initiativeState.vetoLQTY, start, initiativeState.averageStakingTimestampVetoLQTY);
-            initiativeSnapshot.votes = uint224(votes);
-            initiativeSnapshot.vetos = uint224(vetos);
+            initiativeSnapshot.votes = uint120(votes);
+            initiativeSnapshot.vetos = uint120(vetos);
 
             initiativeSnapshot.forEpoch = currentEpoch - 1;
         }

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -248,12 +248,12 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
     }
 
     /// @inheritdoc IGovernance
-    function lqtyToVotes(uint88 _lqtyAmount, uint256 _currentTimestamp, uint32 _averageTimestamp)
+    function lqtyToVotes(uint88 _lqtyAmount, uint32 _currentTimestamp, uint32 _averageTimestamp)
         public
         pure
-        returns (uint240)
+        returns (uint120)
     {
-        return uint240(_lqtyAmount) * _averageAge(uint32(_currentTimestamp), _averageTimestamp);
+        return uint120(_lqtyAmount) * _averageAge(_currentTimestamp, _averageTimestamp);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -137,16 +137,16 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
         uint88 newOuterAverageAge;
         if (_prevLQTYBalance <= _newLQTYBalance) {
             uint88 deltaLQTY = _newLQTYBalance - _prevLQTYBalance;
-            uint240 prevVotes = uint240(_prevLQTYBalance) * uint240(prevOuterAverageAge);
-            uint240 newVotes = uint240(deltaLQTY) * uint240(newInnerAverageAge);
-            uint240 votes = prevVotes + newVotes;
-            newOuterAverageAge = uint32(votes / uint240(_newLQTYBalance));
+            uint120 prevVotes = uint120(_prevLQTYBalance) * uint120(prevOuterAverageAge);
+            uint120 newVotes = uint120(deltaLQTY) * uint120(newInnerAverageAge);
+            uint120 votes = prevVotes + newVotes;
+            newOuterAverageAge = uint32(votes / uint120(_newLQTYBalance));
         } else {
             uint88 deltaLQTY = _prevLQTYBalance - _newLQTYBalance;
-            uint240 prevVotes = uint240(_prevLQTYBalance) * uint240(prevOuterAverageAge);
-            uint240 newVotes = uint240(deltaLQTY) * uint240(newInnerAverageAge);
-            uint240 votes = (prevVotes >= newVotes) ? prevVotes - newVotes : 0;
-            newOuterAverageAge = uint32(votes / uint240(_newLQTYBalance));
+            uint120 prevVotes = uint120(_prevLQTYBalance) * uint120(prevOuterAverageAge);
+            uint120 newVotes = uint120(deltaLQTY) * uint120(newInnerAverageAge);
+            uint120 votes = (prevVotes >= newVotes) ? prevVotes - newVotes : 0;
+            newOuterAverageAge = uint32(votes / uint120(_newLQTYBalance));
         }
 
         if (newOuterAverageAge > block.timestamp) return 0;

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -299,18 +299,22 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
 
         if (shouldUpdate) {
             votesSnapshot = snapshot;
-            uint256 boldBalance = bold.balanceOf(address(this));
             
-            // Cap to u120 or set to 0 if below threshold
-            if(boldBalance > type(uint120).max) {
-                boldBalance = type(uint120).max;
-            } else {
-                boldBalance = (boldBalance < MIN_ACCRUAL) ? 0 : boldBalance;
-            }
-
-            votesSnapshot.boldAccrued = uint120(boldBalance);
             emit SnapshotVotes(snapshot.votes, snapshot.forEpoch);
         }
+    }
+
+    function _computeBoldAccrued() internal view returns (uint120) {
+        uint256 boldBalance = bold.balanceOf(address(this));
+            
+        // Cap to u120 or set to 0 if below threshold
+        if(boldBalance > type(uint120).max) {
+            boldBalance = type(uint120).max;
+        } else {
+            boldBalance = (boldBalance < MIN_ACCRUAL) ? 0 : boldBalance;
+        }
+
+        return uint120(boldBalance);
     }
 
     /// @notice Return the most up to date global snapshot and state as well as a flag to notify whether the state can be updated
@@ -329,6 +333,7 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
 
             snapshot.votes = lqtyToVotes(state.countedVoteLQTY, epochStart(), state.countedVoteLQTYAverageTimestamp);
             snapshot.forEpoch = currentEpoch - 1;
+            snapshot.boldAccrued = _computeBoldAccrued();
         }
     }
 

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -479,7 +479,7 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
         if (
             (_initiativeState.lastEpochClaim + UNREGISTRATION_AFTER_EPOCHS < epoch() - 1)
                 || _votesForInitiativeSnapshot.vetos > _votesForInitiativeSnapshot.votes
-                    && _votesForInitiativeSnapshot.vetos > votingTheshold * UNREGISTRATION_THRESHOLD_FACTOR / WAD
+                    && uint256(_votesForInitiativeSnapshot.vetos) > votingTheshold * UNREGISTRATION_THRESHOLD_FACTOR / WAD
         ) {
             return (InitiativeStatus.UNREGISTERABLE, lastEpochClaim, 0);
         }

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -11,8 +11,8 @@ interface IGovernance {
     event DepositLQTY(address user, uint256 depositedLQTY);
     event WithdrawLQTY(address user, uint256 withdrawnLQTY, uint256 accruedLUSD, uint256 accruedETH);
 
-    event SnapshotVotes(uint240 votes, uint16 forEpoch);
-    event SnapshotVotesForInitiative(address initiative, uint240 votes, uint16 forEpoch);
+    event SnapshotVotes(uint120 votes, uint16 forEpoch);
+    event SnapshotVotesForInitiative(address initiative, uint120 votes, uint16 forEpoch);
 
     event RegisterInitiative(address initiative, address registrant, uint16 atEpoch);
     event UnregisterInitiative(address initiative, uint16 atEpoch);
@@ -84,21 +84,21 @@ interface IGovernance {
     function boldAccrued() external view returns (uint256 boldAccrued);
 
     struct VoteSnapshot {
-        uint240 votes; // Votes at epoch transition
+        uint120 votes; // Votes at epoch transition
         uint16 forEpoch; // Epoch for which the votes are counted
     }
 
     struct InitiativeVoteSnapshot {
-        uint224 votes; // Votes at epoch transition
+        uint120 votes; // Votes at epoch transition
         uint16 forEpoch; // Epoch for which the votes are counted
         uint16 lastCountedEpoch; // Epoch at which which the votes where counted last in the global snapshot
-        uint224 vetos; // Vetos at epoch transition
+        uint120 vetos; // Vetos at epoch transition
     }
 
     /// @notice Returns the vote count snapshot of the previous epoch
     /// @return votes Number of votes
     /// @return forEpoch Epoch for which the votes are counted
-    function votesSnapshot() external view returns (uint240 votes, uint16 forEpoch);
+    function votesSnapshot() external view returns (uint120 votes, uint16 forEpoch);
     /// @notice Returns the vote count snapshot for an initiative of the previous epoch
     /// @param _initiative Address of the initiative
     /// @return votes Number of votes
@@ -107,7 +107,7 @@ interface IGovernance {
     function votesForInitiativeSnapshot(address _initiative)
         external
         view
-        returns (uint224 votes, uint16 forEpoch, uint16 lastCountedEpoch, uint224 vetos);
+        returns (uint120 votes, uint16 forEpoch, uint16 lastCountedEpoch, uint120 vetos);
 
     struct Allocation {
         uint88 voteLQTY; // LQTY allocated vouching for the initiative

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -81,11 +81,12 @@ interface IGovernance {
 
     /// @notice Returns the amount of BOLD accrued since last epoch (last snapshot)
     /// @return boldAccrued BOLD accrued
-    function boldAccrued() external view returns (uint256 boldAccrued);
+    function boldAccrued() external view returns (uint120 boldAccrued);
 
     struct VoteSnapshot {
         uint120 votes; // Votes at epoch transition
         uint16 forEpoch; // Epoch for which the votes are counted
+        uint120 boldAccrued; /// 1e18 * 1e18
     }
 
     struct InitiativeVoteSnapshot {
@@ -98,7 +99,7 @@ interface IGovernance {
     /// @notice Returns the vote count snapshot of the previous epoch
     /// @return votes Number of votes
     /// @return forEpoch Epoch for which the votes are counted
-    function votesSnapshot() external view returns (uint120 votes, uint16 forEpoch);
+    function votesSnapshot() external view returns (uint120 votes, uint16 forEpoch, uint120 boldAccrued);
     /// @notice Returns the vote count snapshot for an initiative of the previous epoch
     /// @param _initiative Address of the initiative
     /// @return votes Number of votes

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -215,10 +215,10 @@ interface IGovernance {
     /// @param _currentTimestamp Current timestamp
     /// @param _averageTimestamp Average timestamp at which the LQTY was staked
     /// @return votes Number of votes
-    function lqtyToVotes(uint88 _lqtyAmount, uint256 _currentTimestamp, uint32 _averageTimestamp)
+    function lqtyToVotes(uint88 _lqtyAmount, uint32 _currentTimestamp, uint32 _averageTimestamp)
         external
         pure
-        returns (uint240);
+        returns (uint120);
 
     /// @notice Voting threshold is the max. of either:
     ///   - 4% of the total voting LQTY in the previous epoch

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -416,9 +416,9 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
-        (uint240 votes, uint16 forEpoch) = governance.votesSnapshot();
+        (uint120 votes, uint16 forEpoch) = governance.votesSnapshot();
         assertEq(votes, 1e18);
         assertEq(forEpoch, 1);
 
@@ -454,7 +454,7 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
         (votes, forEpoch) = governance.votesSnapshot();
         assertEq(votes, 10000e18);
@@ -468,8 +468,10 @@ contract GovernanceTest is Test {
     }
 
     // should not revert under any state
+    // THIS TEST IS USELESS | JUST USE THE FUNCTION CALL AND BE DONE
+    // ALSO WE CAN JUST USE INVAIRANTS
     function test_calculateVotingThreshold_fuzz(
-        uint128 _votes,
+        uint120 _votes,
         uint16 _forEpoch,
         uint88 _boldAccrued,
         uint128 _votingThresholdFactor,
@@ -502,11 +504,11 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
-        (uint240 votes, uint16 forEpoch) = governance.votesSnapshot();
-        assertEq(votes, _votes);
-        assertEq(forEpoch, _forEpoch);
+        (uint120 votes, uint16 forEpoch) = governance.votesSnapshot();
+        assertEq(votes, _votes, "votes");
+        assertEq(forEpoch, _forEpoch, "epoch");
 
         vm.store(address(governance), bytes32(uint256(1)), bytes32(abi.encode(_boldAccrued)));
         assertEq(governance.boldAccrued(), _boldAccrued);
@@ -578,11 +580,11 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
-        (uint240 votes, uint16 forEpoch) = governance.votesSnapshot();
-        assertEq(votes, 1e18);
-        assertEq(forEpoch, 1);
+        (uint120 votes, uint16 forEpoch) = governance.votesSnapshot();
+        assertEq(votes, 1e18, "votes");
+        assertEq(forEpoch, 1, "forEpoch");
 
         vm.stopPrank();
 
@@ -622,11 +624,11 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
         (votes, forEpoch) = governance.votesSnapshot();
-        assertEq(votes, 1e18);
-        assertEq(forEpoch, governance.epoch() - 1);
+        assertEq(votes, 1e18, "votes 1");
+        assertEq(forEpoch, governance.epoch() - 1, "for epoch 1");
 
         vm.warp(uint32(block.timestamp) + governance.EPOCH_DURATION() * 3); // 3 more epochs
 
@@ -1567,11 +1569,11 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
-        (uint240 votes, uint16 forEpoch) = governance.votesSnapshot();
-        assertEq(votes, 1e18);
-        assertEq(forEpoch, 1);
+        (uint120 votes, uint16 forEpoch) = governance.votesSnapshot();
+        assertEq(votes, 1e18, "votes");
+        assertEq(forEpoch, 1, "epoch");
 
         vm.startPrank(lusdHolder);
         lusd.transfer(user, 2e18);
@@ -1602,11 +1604,11 @@ contract GovernanceTest is Test {
         vm.store(
             address(governance),
             bytes32(uint256(2)),
-            bytes32(abi.encodePacked(uint16(snapshot.forEpoch), uint240(snapshot.votes)))
+            bytes32(abi.encodePacked(uint120(0), uint16(snapshot.forEpoch), uint120(snapshot.votes)))
         );
         (votes, forEpoch) = governance.votesSnapshot();
-        assertEq(votes, 1);
-        assertEq(forEpoch, governance.epoch() - 1);
+        assertEq(votes, 1, "votes");
+        assertEq(forEpoch, governance.epoch() - 1, "forEpoch");
 
         IGovernance.InitiativeVoteSnapshot memory initiativeSnapshot =
             IGovernance.InitiativeVoteSnapshot(1, governance.epoch() - 1, governance.epoch() - 1, 0);
@@ -1615,17 +1617,18 @@ contract GovernanceTest is Test {
             keccak256(abi.encode(address(mockInitiative), uint256(3))),
             bytes32(
                 abi.encodePacked(
+                    uint104(0),
                     uint16(initiativeSnapshot.lastCountedEpoch),
                     uint16(initiativeSnapshot.forEpoch),
-                    uint224(initiativeSnapshot.votes)
+                    uint120(initiativeSnapshot.votes)
                 )
             )
         );
-        (uint224 votes_, uint16 forEpoch_, uint16 lastCountedEpoch,) =
+        (uint120 votes_, uint16 forEpoch_, uint16 lastCountedEpoch,) =
             governance.votesForInitiativeSnapshot(address(mockInitiative));
-        assertEq(votes_, 1);
-        assertEq(forEpoch_, governance.epoch() - 1);
-        assertEq(lastCountedEpoch, governance.epoch() - 1);
+        assertEq(votes_, 1, "votes 3");
+        assertEq(forEpoch_, governance.epoch() - 1, "epoch 3");
+        assertEq(lastCountedEpoch, governance.epoch() - 1, "last epoch 3");
 
         governance.claimForInitiative(address(mockInitiative));
 
@@ -1637,9 +1640,10 @@ contract GovernanceTest is Test {
             keccak256(abi.encode(address(mockInitiative), uint256(3))),
             bytes32(
                 abi.encodePacked(
+                    uint104(0),
                     uint16(initiativeSnapshot.lastCountedEpoch),
                     uint16(initiativeSnapshot.forEpoch),
-                    uint224(initiativeSnapshot.votes)
+                    uint120(initiativeSnapshot.votes)
                 )
             )
         );

--- a/test/mocks/MockGovernance.sol
+++ b/test/mocks/MockGovernance.sol
@@ -21,11 +21,11 @@ contract MockGovernance {
         return _currentTimestamp - _averageTimestamp;
     }
 
-    function lqtyToVotes(uint88 _lqtyAmount, uint256 _currentTimestamp, uint32 _averageTimestamp)
+    function lqtyToVotes(uint88 _lqtyAmount, uint32 _currentTimestamp, uint32 _averageTimestamp)
         public
         pure
-        returns (uint240)
+        returns (uint120)
     {
-        return uint240(_lqtyAmount) * _averageAge(uint32(_currentTimestamp), _averageTimestamp);
+        return uint120(_lqtyAmount) * _averageAge(_currentTimestamp, _averageTimestamp);
     }
 }

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -5,5 +5,6 @@ import {BeforeAfter} from "./BeforeAfter.sol";
 import {GovernanceProperties} from "./properties/GovernanceProperties.sol";
 import {BribeInitiativeProperties} from "./properties/BribeInitiativeProperties.sol";
 import {SynchProperties} from "./properties/SynchProperties.sol";
+import {RevertProperties} from "./properties/RevertProperties.sol";
 
-abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties {}
+abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties, RevertProperties {}

--- a/test/recon/properties/GovernanceProperties.sol
+++ b/test/recon/properties/GovernanceProperties.sol
@@ -195,13 +195,13 @@ abstract contract GovernanceProperties is BeforeAfter {
                 (, uint32 averageStakingTimestamp) = governance.userStates(users[j]);
                 // add the weight calculated for each user's allocation to the accumulator
                 userWeightAccumulatorForInitiative +=
-                    governance.lqtyToVotes(userVoteLQTY, block.timestamp, averageStakingTimestamp);
+                    governance.lqtyToVotes(userVoteLQTY, uint32(block.timestamp), averageStakingTimestamp);
             }
 
             (uint88 initiativeVoteLQTY,, uint32 initiativeAverageStakingTimestampVoteLQTY,,) =
                 governance.initiativeStates(deployedInitiatives[i]);
             uint240 initiativeWeight =
-                governance.lqtyToVotes(initiativeVoteLQTY, block.timestamp, initiativeAverageStakingTimestampVoteLQTY);
+                governance.lqtyToVotes(initiativeVoteLQTY, uint32(block.timestamp), initiativeAverageStakingTimestampVoteLQTY);
             eq(
                 initiativeWeight,
                 userWeightAccumulatorForInitiative,
@@ -251,7 +251,7 @@ abstract contract GovernanceProperties is BeforeAfter {
 
         (Governance.InitiativeStatus status,,) = governance.getInitiativeState(initiative);
         if (status == Governance.InitiativeStatus.SKIP) {
-            vm.warp(block.timestamp + governance.EPOCH_DURATION());
+            vm.warp(uint32(block.timestamp) + governance.EPOCH_DURATION());
             (Governance.InitiativeStatus newStatus,,) = governance.getInitiativeState(initiative);
             t(
                 uint256(status) == uint256(newStatus)
@@ -274,7 +274,7 @@ abstract contract GovernanceProperties is BeforeAfter {
 
         (Governance.InitiativeStatus status,,) = governance.getInitiativeState(initiative);
         if (status == Governance.InitiativeStatus.UNREGISTERABLE) {
-            vm.warp(block.timestamp + governance.EPOCH_DURATION());
+            vm.warp(uint32(block.timestamp) + governance.EPOCH_DURATION());
             (Governance.InitiativeStatus newStatus,,) = governance.getInitiativeState(initiative);
             t(uint256(status) == uint256(newStatus), "UNREGISTERABLE must remain UNREGISTERABLE");
         }

--- a/test/recon/properties/RevertProperties.sol
+++ b/test/recon/properties/RevertProperties.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity ^0.8.0;
+
+import {BeforeAfter} from "../BeforeAfter.sol";
+import {Governance} from "src/Governance.sol";
+import {IGovernance} from "src/interfaces/IGovernance.sol";
+import {IBribeInitiative} from "src/interfaces/IBribeInitiative.sol";
+
+// The are view functions that should never revert
+abstract contract RevertProperties is BeforeAfter {
+
+    function property_shouldNeverRevertSnapshotAndState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldGetTotalVotesAndState() public {
+        try governance.getTotalVotesAndState() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertepoch() public {
+        try governance.epoch() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertepochStart(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    function property_shouldNeverRevertsecondsWithinEpoch() public {
+        try governance.secondsWithinEpoch() {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    function property_shouldNeverRevertlqtyToVotes() public {
+        // TODO GRAB THE STATE VALUES
+        // governance.lqtyToVotes();
+    }
+
+    function property_shouldNeverRevertgetLatestVotingThreshold() public {
+        try governance.getLatestVotingThreshold() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertcalculateVotingThreshold() public {
+        try governance.calculateVotingThreshold() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetTotalVotesAndState() public {
+        try governance.getTotalVotesAndState() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetInitiativeSnapshotAndState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertsnapshotVotesForInitiative(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.snapshotVotesForInitiative(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetInitiativeState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+}

--- a/test/recon/properties/RevertProperties.sol
+++ b/test/recon/properties/RevertProperties.sol
@@ -81,4 +81,29 @@ abstract contract RevertProperties is BeforeAfter {
             t(false, "should never revert");
         }
     }
+    function property_shouldNeverRevertgetInitiativeState_arbitrary(address initiative) public {
+        try governance.getInitiativeState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    // TODO: Consider adding `getInitiativeState` with random params
+    // Technically not real, but IMO we should make sure it's safe for all params
+
+    function property_shouldNeverRevertgetInitiativeState_arbitrary(
+        address _initiative,
+        IGovernance.VoteSnapshot memory _votesSnapshot,
+        IGovernance.InitiativeVoteSnapshot memory _votesForInitiativeSnapshot,
+        IGovernance.InitiativeState memory _initiativeState
+    ) public {
+        // NOTE: Maybe this can revert due to specific max values
+        try governance.getInitiativeState(
+            _initiative,
+            _votesSnapshot,
+            _votesForInitiativeSnapshot,
+            _initiativeState
+        ) {} catch {
+            t(false, "should never revert");
+        }
+    }
 }


### PR DESCRIPTION
## Invariant Testing Run, with revert checks on all view functions

https://getrecon.xyz/dashboard/jobs/66d7b004-e279-406c-baf5-35b7398f6557

Change `lqtyToVotes` to use a uint120, proven to be safe since the max is bigger than the product of the max uint32 and max of uint88

Also improves packing of storage slots, saving gas, with (I believe) no additional security risk

## WARNING!

I have altered the logical flow of how `boldAccrued` is computed, PLEASE REVIEW THIS!

## Update

Removed references to uint120 in src (except UniV4)

Updated Invariant Testing to check for revert cases

Packed the `boldAccrued` into the snapshot

https://getrecon.xyz/shares/a8a1e527-8dee-454f-8556-384c9d5387e7

## Missing Tests

- [ ] feat: update boldAccrued in snapshot - UNTESTED

## Missing Polish

I made all the snapshot logic "view" and conditionally accruing
Should we change the code to always have only one return value even on view?