### PR TITLE
Fix temp invariant align bribes

### DIFF
--- a/Invariants.MD
+++ b/Invariants.MD
@@ -1,0 +1,10 @@
+Snapshot Solvency
+
+            uint256 claim = _votesForInitiativeSnapshot.votes * boldAccrued / _votesSnapshot.votes;
+For each initiative this is what the value is
+If the initiative is "Claimable" this is what it receives
+The call never reverts
+The sum of claims is less than the boldAccrued
+
+Veto consistency
+

--- a/echidna.yaml
+++ b/echidna.yaml
@@ -1,5 +1,5 @@
-testMode: "assertion"
-prefix: "crytic_"
+testMode: "optimization"
+prefix: "optimize_"
 coverage: true
 corpusDir: "echidna"
 balanceAddr: 0x1043561a8829300000

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -99,10 +99,27 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         );
 
         (uint88 totalLQTY, uint32 totalAverageTimestamp) = _decodeLQTYAllocation(totalLQTYAllocation.value);
-        uint240 totalVotes = governance.lqtyToVotes(totalLQTY, block.timestamp, totalAverageTimestamp);
+        // WHAT HAPPENS IF WE ENFORCE EPOCH AT END?
+        // THEN WE LINEARLY TRANSLATE TO EPOCH END?
+        // EPOCH_START + epoch * EPOCH_DURATION is the time to claim (I think)
+
+        // Since epoch 1 starts at Epoch Start, epoch * Duration goes to the end of 
+        // But is this safe vs last second of the epoch?
+        // I recall having a similar issue already with Velodrome
+        uint32 epochEnd = uint32(governance.EPOCH_START()) + uint32(_epoch) * uint32(governance.EPOCH_DURATION());
+
+        /// @audit User Invariant
+        assert(totalAverageTimestamp <= epochEnd);
+        
+
+        uint240 totalVotes = governance.lqtyToVotes(totalLQTY, epochEnd, totalAverageTimestamp);
         if (totalVotes != 0) {
             (uint88 lqty, uint32 averageTimestamp) = _decodeLQTYAllocation(lqtyAllocation.value);
-            uint240 votes = governance.lqtyToVotes(lqty, block.timestamp, averageTimestamp);
+
+             /// @audit Governance Invariant
+            assert(averageTimestamp <= epochEnd);
+
+            uint240 votes = governance.lqtyToVotes(lqty, epochEnd, averageTimestamp);
             boldAmount = uint256(bribe.boldAmount) * uint256(votes) / uint256(totalVotes);
             bribeTokenAmount = uint256(bribe.bribeTokenAmount) * uint256(votes) / uint256(totalVotes);
         }

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -109,15 +109,15 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         uint32 epochEnd = uint32(governance.EPOCH_START()) + uint32(_epoch) * uint32(governance.EPOCH_DURATION());
 
         /// @audit User Invariant
-        assert(totalAverageTimestamp <= epochEnd);
+        assert(totalAverageTimestamp <= epochEnd); /// NOTE: Tests break because they are not realistic
         
 
         uint240 totalVotes = governance.lqtyToVotes(totalLQTY, epochEnd, totalAverageTimestamp);
         if (totalVotes != 0) {
             (uint88 lqty, uint32 averageTimestamp) = _decodeLQTYAllocation(lqtyAllocation.value);
 
-             /// @audit Governance Invariant
-            assert(averageTimestamp <= epochEnd);
+            /// @audit Governance Invariant
+            assert(averageTimestamp <= epochEnd); /// NOTE: Tests break because they are not realistic
 
             uint240 votes = governance.lqtyToVotes(lqty, epochEnd, averageTimestamp);
             boldAmount = uint256(bribe.boldAmount) * uint256(votes) / uint256(totalVotes);

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -843,10 +843,12 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
 
     /// @inheritdoc IGovernance
     function claimForInitiative(address _initiative) external nonReentrant returns (uint256) {
+        // Accrue and update state
         (VoteSnapshot memory votesSnapshot_,) = _snapshotVotes();
         (InitiativeVoteSnapshot memory votesForInitiativeSnapshot_, InitiativeState memory initiativeState) =
             _snapshotVotesForInitiative(_initiative);
 
+        // Compute values on accrued state
         (InitiativeStatus status,, uint256 claimableAmount) =
             getInitiativeState(_initiative, votesSnapshot_, votesForInitiativeSnapshot_, initiativeState);
 

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -864,6 +864,14 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
         /// If `lastEpochClaim` is older than epoch() - 1 it means the initiative couldn't claim any rewards this epoch
         initiativeStates[_initiative].lastEpochClaim = epoch() - 1;
 
+        // @audit INVARIANT, because of rounding errors the system can overpay
+        /// We upscale the timestamp to reduce the impact of the loss
+        /// However this is still possible
+        uint256 available = bold.balanceOf(address(this));
+        if(claimableAmount > available) {
+            claimableAmount = available;
+        }
+
         bold.safeTransfer(_initiative, claimableAmount);
 
         emit ClaimForInitiative(_initiative, claimableAmount, votesSnapshot_.forEpoch);

--- a/test/BribeInitiativeAllocate.t.sol
+++ b/test/BribeInitiativeAllocate.t.sol
@@ -159,9 +159,12 @@ contract BribeInitiativeAllocateTest is Test {
 
     function test_onAfterAllocateLQTY_newEpoch_NoVetoToVeto() public {
         governance.setEpoch(1);
+        vm.warp(governance.EPOCH_DURATION()); // warp to end of first epoch
 
         vm.startPrank(address(governance));
 
+        // set user2 allocations like governance would using onAfterAllocateLQTY at epoch 1 
+        // sets avgTimestamp to current block.timestamp
         {
             IGovernance.UserState memory userState =
                 IGovernance.UserState({allocatedLQTY: 1e18, averageStakingTimestamp: uint32(block.timestamp)});
@@ -184,6 +187,8 @@ contract BribeInitiativeAllocateTest is Test {
             assertEq(userAverageTimestamp, uint32(block.timestamp));
         }
 
+        // set user2 allocations like governance would using onAfterAllocateLQTY at epoch 1
+        // sets avgTimestamp to current block.timestamp 
         {
             IGovernance.UserState memory userState =
                 IGovernance.UserState({allocatedLQTY: 1e18, averageStakingTimestamp: uint32(block.timestamp)});
@@ -196,6 +201,7 @@ contract BribeInitiativeAllocateTest is Test {
                 lastEpochClaim: 0
             });
             bribeInitiative.onAfterAllocateLQTY(governance.epoch(), user2, userState, allocation, initiativeState);
+            
             (uint88 totalLQTYAllocated, uint32 totalAverageTimestamp) =
                 bribeInitiative.totalLQTYAllocatedByEpoch(governance.epoch());
             assertEq(totalLQTYAllocated, 1001e18);
@@ -206,6 +212,7 @@ contract BribeInitiativeAllocateTest is Test {
             assertEq(userAverageTimestamp, uint32(block.timestamp));
         }
 
+        // lusdHolder deposits bribes into the initiative
         vm.startPrank(lusdHolder);
         lqty.approve(address(bribeInitiative), 1000e18);
         lusd.approve(address(bribeInitiative), 1000e18);
@@ -213,9 +220,12 @@ contract BribeInitiativeAllocateTest is Test {
         vm.stopPrank();
 
         governance.setEpoch(2);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to second epoch ts
 
         vm.startPrank(address(governance));
 
+        // set allocation in initiative for user in epoch 1 
+        // sets avgTimestamp to current block.timestamp 
         {
             IGovernance.UserState memory userState =
                 IGovernance.UserState({allocatedLQTY: 1e18, averageStakingTimestamp: uint32(block.timestamp)});
@@ -238,6 +248,8 @@ contract BribeInitiativeAllocateTest is Test {
             assertEq(userAverageTimestamp, uint32(block.timestamp));
         }
 
+        // set allocation in initiative for user2 in epoch 1
+        // sets avgTimestamp to current block.timestamp 
         {
             IGovernance.UserState memory userState =
                 IGovernance.UserState({allocatedLQTY: 1e18, averageStakingTimestamp: uint32(block.timestamp)});
@@ -260,7 +272,8 @@ contract BribeInitiativeAllocateTest is Test {
             assertEq(userAverageTimestamp, uint32(block.timestamp));
         }
 
-        governance.setEpoch(3);
+        governance.setEpoch(3); 
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to third epoch ts
 
         vm.startPrank(address(user));
 
@@ -269,12 +282,13 @@ contract BribeInitiativeAllocateTest is Test {
         claimData[0].prevLQTYAllocationEpoch = 2;
         claimData[0].prevTotalLQTYAllocationEpoch = 2;
         (uint256 boldAmount, uint256 bribeTokenAmount) = bribeInitiative.claimBribes(claimData);
-        assertEq(boldAmount, 0);
-        assertEq(bribeTokenAmount, 0);
+        assertEq(boldAmount, 0, "boldAmount nonzero");
+        assertEq(bribeTokenAmount, 0, "bribeTokenAmount nonzero");
     }
 
     function test_onAfterAllocateLQTY_newEpoch_VetoToNoVeto() public {
         governance.setEpoch(1);
+        vm.warp(governance.EPOCH_DURATION()); // warp to end of first epoch
 
         vm.startPrank(address(governance));
 
@@ -325,6 +339,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(userAverageTimestampAfterVeto, uint32(block.timestamp));
 
         governance.setEpoch(2);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to second epoch ts
 
         IGovernance.UserState memory userStateNewEpoch =
             IGovernance.UserState({allocatedLQTY: 1, averageStakingTimestamp: uint32(block.timestamp)});
@@ -359,6 +374,7 @@ contract BribeInitiativeAllocateTest is Test {
         vm.startPrank(address(governance));
 
         governance.setEpoch(3);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to third epoch ts
 
         IGovernance.UserState memory userStateNewEpoch3 =
             IGovernance.UserState({allocatedLQTY: 2000e18, averageStakingTimestamp: uint32(block.timestamp)});
@@ -385,6 +401,7 @@ contract BribeInitiativeAllocateTest is Test {
         assertEq(userAverageTimestampNewEpoch3, uint32(block.timestamp));
 
         governance.setEpoch(4);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to fourth epoch ts
 
         vm.startPrank(address(user));
 
@@ -509,6 +526,7 @@ contract BribeInitiativeAllocateTest is Test {
         vm.stopPrank();
 
         governance.setEpoch(1);
+        vm.warp(governance.EPOCH_DURATION()); // warp to end of first epoch
 
         vm.startPrank(address(governance));
 
@@ -585,6 +603,7 @@ contract BribeInitiativeAllocateTest is Test {
         }
 
         governance.setEpoch(2);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to second epoch ts
 
         vm.startPrank(address(user));
 
@@ -603,6 +622,7 @@ contract BribeInitiativeAllocateTest is Test {
         vm.stopPrank();
 
         governance.setEpoch(1);
+        vm.warp(governance.EPOCH_DURATION()); // warp to end of first epoch
 
         vm.startPrank(address(governance));
 
@@ -679,6 +699,7 @@ contract BribeInitiativeAllocateTest is Test {
         }
 
         governance.setEpoch(2);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to second epoch ts
 
         vm.startPrank(address(user));
 
@@ -699,6 +720,7 @@ contract BribeInitiativeAllocateTest is Test {
         vm.stopPrank();
 
         governance.setEpoch(1);
+        vm.warp(governance.EPOCH_DURATION()); // warp to end of first epoch
 
         vm.startPrank(address(governance));
 
@@ -799,6 +821,7 @@ contract BribeInitiativeAllocateTest is Test {
         }
 
         governance.setEpoch(2);
+        vm.warp(block.timestamp + governance.EPOCH_DURATION()); // warp to second epoch ts
 
         vm.startPrank(address(user));
 

--- a/test/mocks/MockGovernance.sol
+++ b/test/mocks/MockGovernance.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 contract MockGovernance {
     uint16 private __epoch;
 
+    uint32 constant public EPOCH_START = 0;
+    uint32 constant public EPOCH_DURATION = 7 days;
+
     function claimForInitiative(address) external pure returns (uint256) {
         return 1000e18;
     }

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -79,4 +79,53 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
         property_BI04();
     }
+
+    // forge test --match-test test_governance_claimForInitiativeDoesntRevert_5 -vv 
+ function test_governance_claimForInitiativeDoesntRevert_5() public {
+
+     governance_depositLQTY_2(96505858);
+
+     vm.roll(block.number + 3);
+     vm.warp(block.timestamp + 191303);
+     property_BI03();
+
+     vm.warp(block.timestamp + 100782);
+
+     vm.roll(block.number + 1);
+
+     vm.roll(block.number + 1);
+     vm.warp(block.timestamp + 344203);
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,1,0);
+
+     vm.warp(block.timestamp + 348184);
+
+     vm.roll(block.number + 177);
+
+     helper_deployInitiative();
+
+     helper_accrueBold(1000135831883853852074);
+
+     governance_depositLQTY(2293362807359);
+
+     vm.roll(block.number + 2);
+     vm.warp(block.timestamp + 151689);
+     property_BI04();
+
+     governance_registerInitiative(1);
+
+     vm.roll(block.number + 3);
+     vm.warp(block.timestamp + 449572);
+     governance_allocateLQTY_clamped_single_initiative(1,330671315851182842292,0);
+
+     governance_resetAllocations();
+
+     vm.warp(block.timestamp + 231771);
+
+     vm.roll(block.number + 5);
+
+        // WOW, 7X off
+    console.log("Balance prev", lusd.balanceOf(address(governance)));
+     governance_claimForInitiativeDoesntRevert(0);
+
+ }
 }

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {TargetFunctions} from "./TargetFunctions.sol";
 import {FoundryAsserts} from "@chimera/FoundryAsserts.sol";
 import {IBribeInitiative} from "src/interfaces/IBribeInitiative.sol";
+import {IGovernance} from "src/interfaces/IGovernance.sol";
+import {Governance} from "src/Governance.sol";
 
 import {console} from "forge-std/console.sol";
 
@@ -13,81 +15,137 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         setup();
     }
 
-    /// Example fixed bribes properties
-    // Use `https://getrecon.xyz/tools/echidna` to scrape properties into this format
-    // forge test --match-test test_property_BI03_1 -vv
-    function test_property_BI03_1() public {
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 239415);
-        governance_depositLQTY(2);
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 366071);
-        governance_allocateLQTY_clamped_single_initiative(0, 1, 0);
-        check_skip_consistecy(0);
-        property_BI03();
-    }
+ // forge test --match-test test_property_sum_of_initatives_matches_total_votes_2 -vv 
+ function test_property_sum_of_initatives_matches_total_votes_2() public {
 
-    // forge test --match-test test_property_BI04_4 -vv
-    function test_property_BI04_4() public {
-        governance_depositLQTY(2);
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 606998);
-        governance_allocateLQTY_clamped_single_initiative(0, 0, 1);
-        property_BI04();
-    }
+     governance_depositLQTY_2(2);
 
-    // forge test --match-test test_property_resetting_never_reverts_0 -vv
-    function test_property_resetting_never_reverts_0() public {
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 193521);
-        governance_depositLQTY(155989603725201422915398867);
+     vm.warp(block.timestamp + 434544);
 
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 411452);
-        governance_allocateLQTY_clamped_single_initiative(0, 0, 154742504910672534362390527);
+     vm.roll(block.number + 1);
 
-        property_resetting_never_reverts();
-    }
+     vm.roll(block.number + 1);
+     vm.warp(block.timestamp + 171499);
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,1,0);
 
-    // forge test --match-test test_property_BI11_3 -vv
-    function test_property_BI11_3() public {
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 461046);
-        governance_depositLQTY(2);
+     helper_deployInitiative();
 
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 301396);
-        governance_allocateLQTY_clamped_single_initiative(0, 1, 0);
+     governance_depositLQTY(2);
 
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 450733);
-        initiative_claimBribes(0, 3, 0, 0);
-        property_BI11();
-    }
+     vm.warp(block.timestamp + 322216);
 
-    // forge test --match-test test_property_BI04_1 -vv
-    function test_property_BI04_1() public {
-        governance_depositLQTY(2);
+     vm.roll(block.number + 1);
 
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 654326);
-        governance_allocateLQTY_clamped_single_initiative(0, 1, 0);
+     governance_registerInitiative(1);
 
-        vm.roll(block.number + 1);
-        vm.warp(block.timestamp + 559510);
-        property_resetting_never_reverts();
+     vm.roll(block.number + 1);
+     vm.warp(block.timestamp + 449572);
+     governance_allocateLQTY_clamped_single_initiative(1,75095343,0);
 
-        property_BI04();
-    }
+     vm.roll(block.number + 1);
+     vm.warp(block.timestamp + 436994);
+     property_sum_of_initatives_matches_total_votes();
+     // Of by 1
+     // I think this should be off by a bit more than 1
+     // But ultimately always less
 
-    // forge test --match-test test_governance_claimForInitiativeDoesntRevert_5 -vv 
+ }
+
+ // forge test --match-test test_property_sum_of_user_voting_weights_0 -vv 
+ function test_property_sum_of_user_voting_weights_0() public {
+
+     vm.warp(block.timestamp + 365090);
+
+     vm.roll(block.number + 1);
+
+     governance_depositLQTY_2(3);
+
+     vm.warp(block.timestamp + 164968);
+
+     vm.roll(block.number + 1);
+
+     governance_depositLQTY(2);
+
+     vm.warp(block.timestamp + 74949);
+
+     vm.roll(block.number + 1);
+
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,2,0);
+
+     governance_allocateLQTY_clamped_single_initiative(0,1,0);
+
+     property_sum_of_user_voting_weights(); /// Of by 2
+
+ }
+
+ // forge test --match-test test_property_sum_of_lqty_global_user_matches_3 -vv 
+ function test_property_sum_of_lqty_global_user_matches_3() public {
+
+     vm.roll(block.number + 2);
+     vm.warp(block.timestamp + 45381);
+     governance_depositLQTY_2(161673733563);
+
+     vm.roll(block.number + 92);
+     vm.warp(block.timestamp + 156075);
+     property_BI03();
+
+     vm.roll(block.number + 305);
+     vm.warp(block.timestamp + 124202);
+     property_BI04();
+
+     vm.roll(block.number + 2);
+     vm.warp(block.timestamp + 296079);
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,1,0);
+
+     vm.roll(block.number + 4);
+     vm.warp(block.timestamp + 179667);
+     helper_deployInitiative();
+
+     governance_depositLQTY(2718660550802480907);
+
+     vm.roll(block.number + 6);
+     vm.warp(block.timestamp + 383590);
+     property_BI07();
+
+     vm.warp(block.timestamp + 246073);
+
+     vm.roll(block.number + 79);
+
+     vm.roll(block.number + 4);
+     vm.warp(block.timestamp + 322216);
+     governance_depositLQTY(1);
+
+     vm.warp(block.timestamp + 472018);
+
+     vm.roll(block.number + 215);
+
+     governance_registerInitiative(1);
+
+     vm.roll(block.number + 1);
+     vm.warp(block.timestamp + 419805);
+     governance_allocateLQTY_clamped_single_initiative(1,3700338125821584341973,0);
+
+     vm.warp(block.timestamp + 379004);
+
+     vm.roll(block.number + 112);
+
+     governance_unregisterInitiative(0);
+
+     property_sum_of_lqty_global_user_matches();
+
+ }
+
+ // forge test --match-test test_governance_claimForInitiativeDoesntRevert_5 -vv 
  function test_governance_claimForInitiativeDoesntRevert_5() public {
 
      governance_depositLQTY_2(96505858);
+     _loginitiative_and_state(); // 0
+
 
      vm.roll(block.number + 3);
      vm.warp(block.timestamp + 191303);
      property_BI03();
+     _loginitiative_and_state(); // 1
 
      vm.warp(block.timestamp + 100782);
 
@@ -96,36 +154,91 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
      vm.roll(block.number + 1);
      vm.warp(block.timestamp + 344203);
      governance_allocateLQTY_clamped_single_initiative_2nd_user(0,1,0);
+     _loginitiative_and_state(); // 2
 
      vm.warp(block.timestamp + 348184);
 
      vm.roll(block.number + 177);
 
      helper_deployInitiative();
+     _loginitiative_and_state(); // 3
 
      helper_accrueBold(1000135831883853852074);
+     _loginitiative_and_state(); // 4
 
      governance_depositLQTY(2293362807359);
+     _loginitiative_and_state(); // 5
 
      vm.roll(block.number + 2);
      vm.warp(block.timestamp + 151689);
      property_BI04();
+     _loginitiative_and_state(); // 6
 
      governance_registerInitiative(1);
+     _loginitiative_and_state(); // 7
+     property_sum_of_initatives_matches_total_votes();
 
      vm.roll(block.number + 3);
      vm.warp(block.timestamp + 449572);
      governance_allocateLQTY_clamped_single_initiative(1,330671315851182842292,0);
+    _loginitiative_and_state(); // 8
+    property_sum_of_initatives_matches_total_votes();
 
      governance_resetAllocations();
+     _loginitiative_and_state();
+     property_sum_of_initatives_matches_total_votes();
 
      vm.warp(block.timestamp + 231771);
-
      vm.roll(block.number + 5);
+     _loginitiative_and_state();
 
-        // WOW, 7X off
-    console.log("Balance prev", lusd.balanceOf(address(governance)));
-     governance_claimForInitiativeDoesntRevert(0);
+    // Both of these are fine
+    // Meaning all LQTY allocation is fine here
+    // Same for user voting weights
+    property_sum_of_user_voting_weights();
+    property_sum_of_lqty_global_user_matches();
 
+    /// === BROKEN === ///
+     property_sum_of_initatives_matches_total_votes(); // THIS IS THE BROKEN PROPERTY
+    (IGovernance.VoteSnapshot memory snapshot,,) = governance.getTotalVotesAndState();
+
+        uint256 initiativeVotesSum;
+        for (uint256 i; i < deployedInitiatives.length; i++) {
+            (IGovernance.InitiativeVoteSnapshot memory initiativeSnapshot,,) =
+                governance.getInitiativeSnapshotAndState(deployedInitiatives[i]);
+            (Governance.InitiativeStatus status,,) = governance.getInitiativeState(deployedInitiatives[i]);
+
+            // if (status != Governance.InitiativeStatus.DISABLED) {
+                // FIX: Only count total if initiative is not disabled
+                initiativeVotesSum += initiativeSnapshot.votes;
+            // }
+        }
+    console.log("snapshot.votes", snapshot.votes);
+    console.log("initiativeVotesSum", initiativeVotesSum);
+    console.log("bold.balance", lusd.balanceOf(address(governance)));
+    //  governance_claimForInitiativeDoesntRevert(0);
+
+ }
+
+uint256 loggerCount;
+ function _loginitiative_and_state() internal {
+    (IGovernance.VoteSnapshot memory snapshot, IGovernance.GlobalState memory state,) = governance.getTotalVotesAndState();
+    console.log("");
+    console.log("loggerCount", loggerCount++);
+    console.log("snapshot.votes", snapshot.votes);
+
+    console.log("state.countedVoteLQTY", state.countedVoteLQTY);
+    console.log("state.countedVoteLQTYAverageTimestamp", state.countedVoteLQTYAverageTimestamp);
+
+    for (uint256 i; i < deployedInitiatives.length; i++) {
+            (IGovernance.InitiativeVoteSnapshot memory initiativeSnapshot, IGovernance.InitiativeState memory initiativeState,) =
+                governance.getInitiativeSnapshotAndState(deployedInitiatives[i]);
+
+            console.log("initiativeState.voteLQTY", initiativeState.voteLQTY);
+            console.log("initiativeState.averageStakingTimestampVoteLQTY", initiativeState.averageStakingTimestampVoteLQTY);
+
+        assertEq(snapshot.forEpoch, initiativeSnapshot.forEpoch, "No desynch");
+         console.log("initiativeSnapshot.votes", initiativeSnapshot.votes);
+    }
  }
 }

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -184,9 +184,9 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     _loginitiative_and_state(); // 8
     property_sum_of_initatives_matches_total_votes();
 
-     governance_resetAllocations();
-     _loginitiative_and_state();
-     property_sum_of_initatives_matches_total_votes();
+    //  governance_resetAllocations();
+    //  _loginitiative_and_state();
+    //  property_sum_of_initatives_matches_total_votes();
 
      vm.warp(block.timestamp + 231771);
      vm.roll(block.number + 5);

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -184,13 +184,15 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     _loginitiative_and_state(); // 8
     property_sum_of_initatives_matches_total_votes();
 
-     governance_resetAllocations();
-     _loginitiative_and_state();
+     governance_resetAllocations(); // NOTE: This leaves 1 vote from user2, and removes the votes from user1
+     _loginitiative_and_state(); // In lack of reset, we have 2 wei error | With reset the math is off by 7x
      property_sum_of_initatives_matches_total_votes();
+     console.log("time 0", block.timestamp);
 
      vm.warp(block.timestamp + 231771);
      vm.roll(block.number + 5);
      _loginitiative_and_state();
+      console.log("time 0", block.timestamp);
 
     // Both of these are fine
     // Meaning all LQTY allocation is fine here
@@ -199,7 +201,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     property_sum_of_lqty_global_user_matches();
 
     /// === BROKEN === ///
-     property_sum_of_initatives_matches_total_votes(); // THIS IS THE BROKEN PROPERTY
+    //  property_sum_of_initatives_matches_total_votes(); // THIS IS THE BROKEN PROPERTY
     (IGovernance.VoteSnapshot memory snapshot,,) = governance.getTotalVotesAndState();
 
         uint256 initiativeVotesSum;
@@ -216,8 +218,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     console.log("snapshot.votes", snapshot.votes);
     console.log("initiativeVotesSum", initiativeVotesSum);
     console.log("bold.balance", lusd.balanceOf(address(governance)));
-    //  governance_claimForInitiativeDoesntRevert(0);
-
+     governance_claimForInitiativeDoesntRevert(0); // Because of the quickfix this will not revert anymore
  }
 
 uint256 loggerCount;
@@ -268,6 +269,33 @@ uint256 loggerCount;
      property_resetting_never_reverts();
 
      property_BI07();
+
+ }
+
+ // forge test --match-test test_property_sum_of_user_voting_weights_0 -vv 
+ function test_property_sum_of_user_voting_weights_1() public {
+
+     vm.warp(block.timestamp + 365090);
+
+     vm.roll(block.number + 1);
+
+     governance_depositLQTY_2(3);
+
+     vm.warp(block.timestamp + 164968);
+
+     vm.roll(block.number + 1);
+
+     governance_depositLQTY(2);
+
+     vm.warp(block.timestamp + 74949);
+
+     vm.roll(block.number + 1);
+
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,2,0);
+
+     governance_allocateLQTY_clamped_single_initiative(0,1,0);
+
+     property_sum_of_user_voting_weights();
 
  }
 }

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -241,4 +241,33 @@ uint256 loggerCount;
          console.log("initiativeSnapshot.votes", initiativeSnapshot.votes);
     }
  }
+
+ // forge test --match-test test_property_BI07_4 -vv 
+ function test_property_BI07_4() public {
+
+     vm.warp(block.timestamp + 562841);
+
+     vm.roll(block.number + 1);
+
+     governance_depositLQTY_2(2);
+
+     vm.warp(block.timestamp + 243877);
+
+     vm.roll(block.number + 1);
+
+     governance_allocateLQTY_clamped_single_initiative_2nd_user(0,1,0);
+
+     vm.warp(block.timestamp + 403427);
+
+     vm.roll(block.number + 1);
+
+    // SHIFTS the week
+    // Doesn't check latest alloc for each user
+    // Property is broken due to wrong spec
+    // For each user you need to grab the latest via the Governance.allocatedByUser
+     property_resetting_never_reverts();
+
+     property_BI07();
+
+ }
 }

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -184,9 +184,9 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     _loginitiative_and_state(); // 8
     property_sum_of_initatives_matches_total_votes();
 
-    //  governance_resetAllocations();
-    //  _loginitiative_and_state();
-    //  property_sum_of_initatives_matches_total_votes();
+     governance_resetAllocations();
+     _loginitiative_and_state();
+     property_sum_of_initatives_matches_total_votes();
 
      vm.warp(block.timestamp + 231771);
      vm.roll(block.number + 5);

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 import {BeforeAfter} from "./BeforeAfter.sol";
-import {GovernanceProperties} from "./properties/GovernanceProperties.sol";
+import {OptimizationProperties} from "./properties/OptimizationProperties.sol";
 import {BribeInitiativeProperties} from "./properties/BribeInitiativeProperties.sol";
 import {SynchProperties} from "./properties/SynchProperties.sol";
 
-abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties {}
+abstract contract Properties is OptimizationProperties, BribeInitiativeProperties, SynchProperties {}

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -5,6 +5,5 @@ import {BeforeAfter} from "./BeforeAfter.sol";
 import {GovernanceProperties} from "./properties/GovernanceProperties.sol";
 import {BribeInitiativeProperties} from "./properties/BribeInitiativeProperties.sol";
 import {SynchProperties} from "./properties/SynchProperties.sol";
-import {SolvencyProperties} from "./properties/SolvencyProperties.sol";
 
-abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties, SolvencyProperties {}
+abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties {}

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -5,5 +5,6 @@ import {BeforeAfter} from "./BeforeAfter.sol";
 import {GovernanceProperties} from "./properties/GovernanceProperties.sol";
 import {BribeInitiativeProperties} from "./properties/BribeInitiativeProperties.sol";
 import {SynchProperties} from "./properties/SynchProperties.sol";
+import {SolvencyProperties} from "./properties/SolvencyProperties.sol";
 
-abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties {}
+abstract contract Properties is GovernanceProperties, BribeInitiativeProperties, SynchProperties, SolvencyProperties {}

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.0;
 
 import {BeforeAfter} from "./BeforeAfter.sol";
+
+// NOTE: OptimizationProperties imports Governance properties, to reuse a few fetchers
 import {OptimizationProperties} from "./properties/OptimizationProperties.sol";
 import {BribeInitiativeProperties} from "./properties/BribeInitiativeProperties.sol";
 import {SynchProperties} from "./properties/SynchProperties.sol";
+import {RevertProperties} from "./properties/RevertProperties.sol";
 
-abstract contract Properties is OptimizationProperties, BribeInitiativeProperties, SynchProperties {}
+abstract contract Properties is OptimizationProperties, BribeInitiativeProperties, SynchProperties, RevertProperties {}

--- a/test/recon/Setup.sol
+++ b/test/recon/Setup.sol
@@ -22,7 +22,7 @@ abstract contract Setup is BaseSetup {
     address internal user2 = address(0x537C8f3d3E18dF5517a58B3fB9D9143697996802); // derived using makeAddrAndKey
     address internal stakingV1;
     address internal userProxy;
-    address[] internal users = new address[](2);
+    address[] internal users;
     address[] internal deployedInitiatives;
     uint256 internal user2Pk = 23868421370328131711506074113045611601786642648093516849953535378706721142721; // derived using makeAddrAndKey
     bool internal claimedTwice;

--- a/test/recon/properties/BribeInitiativeProperties.sol
+++ b/test/recon/properties/BribeInitiativeProperties.sol
@@ -181,8 +181,7 @@ abstract contract BribeInitiativeProperties is BeforeAfter {
             IBribeInitiative initiative = IBribeInitiative(deployedInitiatives[i]);
             uint88 sumLqtyAllocated;
             for (uint8 j; j < users.length; j++) {
-                address user = users[j];
-                (uint88 lqtyAllocated,) = initiative.lqtyAllocatedByUserAtEpoch(user, currentEpoch);
+                (uint88 lqtyAllocated,) = initiative.lqtyAllocatedByUserAtEpoch(users[j], currentEpoch);
                 sumLqtyAllocated += lqtyAllocated;
             }
             (uint88 totalLQTYAllocated,) = initiative.totalLQTYAllocatedByEpoch(currentEpoch);

--- a/test/recon/properties/GovernanceProperties.sol
+++ b/test/recon/properties/GovernanceProperties.sol
@@ -116,7 +116,7 @@ abstract contract GovernanceProperties is BeforeAfter {
             totalUserCountedLQTY += user_voteLQTY;
         }
 
-        eq(totalCountedLQTY, totalUserCountedLQTY, "Global vs SUM(Users_lqty) must match");
+        eq(totalUserCountedLQTY, totalCountedLQTY, "Global vs SUM(Users_lqty) must match");
     }
 
 
@@ -237,7 +237,7 @@ abstract contract GovernanceProperties is BeforeAfter {
             }
         }
 
-        eq(snapshot.votes, initiativeVotesSum, "Sum of votes matches");
+        eq(initiativeVotesSum, snapshot.votes, "Sum of votes matches");
     }
 
     /// NOTE: This property can break in some specific combinations of:

--- a/test/recon/properties/OptimizationProperties.sol
+++ b/test/recon/properties/OptimizationProperties.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity ^0.8.0;
+
+import {BeforeAfter} from "../BeforeAfter.sol";
+import {Governance} from "src/Governance.sol";
+import {IGovernance} from "src/interfaces/IGovernance.sol";
+import {MockStakingV1} from "test/mocks/MockStakingV1.sol";
+import {vm} from "@chimera/Hevm.sol";
+import {IUserProxy} from "src/interfaces/IUserProxy.sol";
+import {GovernanceProperties} from "./GovernanceProperties.sol";
+
+abstract contract OptimizationProperties is GovernanceProperties {
+
+    // TODO: Add Optimization for property_sum_of_user_voting_weights
+    function optimize_max_sum_of_user_voting_weights_insolvent() public returns (int256) {
+        VotesSumAndInitiativeSum[] memory results = _getUserVotesSumAndInitiativesVotes();
+
+        int256 max = 0;
+
+        // User have more than initiative, we are insolvent
+        for(uint256 i; i < results.length; i++) {
+            if(results[i].userSum > results[i].initiativeWeight) {
+                max = int256(results[i].userSum) - int256(results[i].initiativeWeight);
+            }
+        }
+
+        return max;
+    }
+    function optimize_max_sum_of_user_voting_weights_underpaying() public returns (int256) {
+        VotesSumAndInitiativeSum[] memory results = _getUserVotesSumAndInitiativesVotes();
+
+        int256 max = 0;
+
+        for(uint256 i; i < results.length; i++) {
+            // Initiative has more than users, we are underpaying
+            if(results[i].initiativeWeight > results[i].userSum) {
+                max = int256(results[i].initiativeWeight) - int256(results[i].userSum);
+            }
+        }
+
+        return max;
+    }
+    
+
+
+    // TODO: Add Optimization for property_sum_of_lqty_global_user_matches
+    function optimize_property_sum_of_lqty_global_user_matches_insolvency() public returns (int256) {
+
+        int256 max = 0;
+
+        (uint256 totalUserCountedLQTY, uint256 totalCountedLQTY) = _getGlobalLQTYAndUserSum();
+
+        if(totalUserCountedLQTY > totalCountedLQTY) {
+            max = int256(totalUserCountedLQTY) - int256(totalCountedLQTY);
+        }
+
+        return max;
+    }
+    function optimize_property_sum_of_lqty_global_user_matches_underpaying() public returns (int256) {
+
+        int256 max = 0;
+
+        (uint256 totalUserCountedLQTY, uint256 totalCountedLQTY) = _getGlobalLQTYAndUserSum();
+
+        if(totalCountedLQTY > totalUserCountedLQTY) {
+            max = int256(totalCountedLQTY) - int256(totalUserCountedLQTY);
+        }
+
+        return max;
+    }
+
+        // TODO: Add Optimization for property_sum_of_initatives_matches_total_votes
+
+    function optimize_property_sum_of_initatives_matches_total_votes_insolvency() public returns (int256) {
+
+        int256 max = 0;
+
+        (uint256 sumVotes, uint256 totalVotes) = _getInitiativesSnapshotsAndGlobalState();
+
+        if(sumVotes > totalVotes) {
+            max = int256(sumVotes) - int256(totalVotes);
+        }
+
+        return max;
+    }
+    function optimize_property_sum_of_initatives_matches_total_votes_underpaying() public returns (int256) {
+
+        int256 max = 0;
+
+        (uint256 sumVotes, uint256 totalVotes) = _getInitiativesSnapshotsAndGlobalState();
+
+        if(totalVotes > sumVotes) {
+            max = int256(totalVotes) - int256(sumVotes);
+        }
+
+        return max;
+    }
+
+
+}
+    

--- a/test/recon/properties/RevertProperties.sol
+++ b/test/recon/properties/RevertProperties.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity ^0.8.0;
+
+import {BeforeAfter} from "../BeforeAfter.sol";
+import {Governance} from "src/Governance.sol";
+import {IGovernance} from "src/interfaces/IGovernance.sol";
+import {IBribeInitiative} from "src/interfaces/IBribeInitiative.sol";
+
+// The are view functions that should never revert
+abstract contract RevertProperties is BeforeAfter {
+
+    function property_shouldNeverRevertSnapshotAndState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldGetTotalVotesAndState() public {
+        try governance.getTotalVotesAndState() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertepoch() public {
+        try governance.epoch() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertepochStart(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    function property_shouldNeverRevertsecondsWithinEpoch() public {
+        try governance.secondsWithinEpoch() {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    function property_shouldNeverRevertlqtyToVotes() public {
+        // TODO GRAB THE STATE VALUES
+        // governance.lqtyToVotes();
+    }
+
+    function property_shouldNeverRevertgetLatestVotingThreshold() public {
+        try governance.getLatestVotingThreshold() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertcalculateVotingThreshold() public {
+        try governance.calculateVotingThreshold() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetTotalVotesAndState() public {
+        try governance.getTotalVotesAndState() {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetInitiativeSnapshotAndState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeSnapshotAndState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertsnapshotVotesForInitiative(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.snapshotVotesForInitiative(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetInitiativeState(uint8 initiativeIndex) public {
+        address initiative = _getDeployedInitiative(initiativeIndex);
+
+        try governance.getInitiativeState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+    function property_shouldNeverRevertgetInitiativeState_arbitrary(address initiative) public {
+        try governance.getInitiativeState(initiative) {} catch {
+            t(false, "should never revert");
+        }
+    }
+
+    // TODO: Consider adding `getInitiativeState` with random params
+    // Technically not real, but IMO we should make sure it's safe for all params
+
+    function property_shouldNeverRevertgetInitiativeState_arbitrary(
+        address _initiative,
+        IGovernance.VoteSnapshot memory _votesSnapshot,
+        IGovernance.InitiativeVoteSnapshot memory _votesForInitiativeSnapshot,
+        IGovernance.InitiativeState memory _initiativeState
+    ) public {
+        // NOTE: Maybe this can revert due to specific max values
+        try governance.getInitiativeState(
+            _initiative,
+            _votesSnapshot,
+            _votesForInitiativeSnapshot,
+            _initiativeState
+        ) {} catch {
+            t(false, "should never revert");
+        }
+    }
+}


### PR DESCRIPTION
## Critical Insolvency Repro

```forge test --match-test test_governance_claimForInitiativeDoesntRevert_5 -vv```


## PR Changes

Computes `epochEnd`

```solidity
        uint32 epochEnd = uint32(governance.EPOCH_START()) + uint32(_epoch) * uint32(governance.EPOCH_DURATION());
```


https://getrecon.xyz/shares/c7cfcdce-28bc-475f-ba9a-67609a746cad

- [x] Do the invariants hold
- [x] Should we change to epochEnd -1 to prevent quick votes on other chains?



