### PR TITLE
Tweaks to incorporate into core deployment

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 v4-core/=lib/v4-core/
 forge-std/=lib/forge-std/src/
 @chimera/=lib/chimera/src/
+openzeppelin/=lib/openzeppelin-contracts/

--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {IGovernance} from "./interfaces/IGovernance.sol";
 import {IInitiative} from "./interfaces/IInitiative.sol";

--- a/src/ForwardBribe.sol
+++ b/src/ForwardBribe.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {BribeInitiative} from "./BribeInitiative.sol";
 

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ReentrancyGuard} from "openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import {IGovernance} from "./interfaces/IGovernance.sol";
 import {IInitiative} from "./interfaces/IInitiative.sol";

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -73,6 +73,7 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
     mapping(address => mapping(address => Allocation)) public lqtyAllocatedByUserToInitiative;
     /// @inheritdoc IGovernance
     mapping(address => uint16) public override registeredInitiatives;
+    bool private initialInitiativesRegistered;
 
     uint16 constant UNREGISTERED_INITIATIVE = type(uint16).max;
 
@@ -112,10 +113,23 @@ contract Governance is Multicall, UserProxyFactory, ReentrancyGuard, IGovernance
         EPOCH_DURATION = _config.epochDuration;
         require(_config.epochVotingCutoff < _config.epochDuration, "Gov: epoch-voting-cutoff-gt-epoch-duration");
         EPOCH_VOTING_CUTOFF = _config.epochVotingCutoff;
+
+        if (_initiatives.length > 0) {
+            registerInitialInitiatives(_initiatives);
+        }
+    }
+
+    function registerInitialInitiatives(address[] memory _initiatives) public {
+        require(!initialInitiativesRegistered, "Initial inintiatives already registered");
+
         for (uint256 i = 0; i < _initiatives.length; i++) {
             initiativeStates[_initiatives[i]] = InitiativeState(0, 0, 0, 0, 0);
             registeredInitiatives[_initiatives[i]] = 1;
+
+            emit RegisterInitiative(_initiatives[i], msg.sender, 1);
         }
+
+        initialInitiativesRegistered = true;
     }
 
     function _averageAge(uint32 _currentTimestamp, uint32 _averageTimestamp) internal pure returns (uint32) {

--- a/src/UniV4Donations.sol
+++ b/src/UniV4Donations.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
 import {IHooks} from "v4-core/src/interfaces/IHooks.sol";

--- a/src/UserProxy.sol
+++ b/src/UserProxy.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
-import {IERC20Permit} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC20Permit} from "openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {SafeERC20} from "openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {IUserProxy} from "./interfaces/IUserProxy.sol";
 import {ILQTYStaking} from "./interfaces/ILQTYStaking.sol";

--- a/src/UserProxyFactory.sol
+++ b/src/UserProxyFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {Clones} from "openzeppelin-contracts/contracts/proxy/Clones.sol";
+import {Clones} from "openzeppelin/contracts/proxy/Clones.sol";
 
 import {IUserProxyFactory} from "./interfaces/IUserProxyFactory.sol";
 import {UserProxy} from "./UserProxy.sol";

--- a/src/interfaces/IBribeInitiative.sol
+++ b/src/interfaces/IBribeInitiative.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
 
 import {IGovernance} from "./IGovernance.sol";
 

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -34,6 +34,8 @@ interface IGovernance {
         uint32 epochVotingCutoff;
     }
 
+    function registerInitialInitiatives(address[] memory _initiatives) external;
+
     /// @notice Address of the LQTY StakingV1 contract
     /// @return stakingV1 Address of the LQTY StakingV1 contract
     function stakingV1() external view returns (ILQTYStaking stakingV1);

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
 
 import {ILQTYStaking} from "./ILQTYStaking.sol";
 

--- a/src/interfaces/IUserProxy.sol
+++ b/src/interfaces/IUserProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {IERC20} from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {IERC20} from "openzeppelin/contracts/interfaces/IERC20.sol";
 
 import {ILQTYStaking} from "../interfaces/ILQTYStaking.sol";
 

--- a/src/utils/Ownable.sol
+++ b/src/utils/Ownable.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+/**
+ * Based on OpenZeppelin's Ownable contract:
+ * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
+ *
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting `initialOwner` as the initial owner.
+     */
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+        emit OwnershipTransferred(address(0), initialOwner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     *
+     * NOTE: This function is not safe, as it doesn’t check owner is calling it.
+     * Make sure you check it before calling it.
+     */
+    function _renounceOwnership() internal {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+}


### PR DESCRIPTION
- Rename openzeppelin remappings, so we can use different versions in core and governance (as suggested by @danielattilasimon )
- Move initial initiatives into a separate function, so we can call it in 2 txs and avoid circular dependencies when using CREATE2