### PR TITLE
fix: Move lqty allocation checks

### DIFF
--- a/src/BribeInitiative.sol
+++ b/src/BribeInitiative.sol
@@ -100,7 +100,7 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         );
 
         (uint88 totalLQTY, uint120 totalAverageTimestamp) = _decodeLQTYAllocation(totalLQTYAllocation.value);
-        require(totalLQTY > 0, "BribeInitiative: invalid-prev-total-lqty");
+        require(totalLQTY > 0, "BribeInitiative: total-lqty-allocation-zero");
 
         // NOTE: SCALING!!! | The timestamp will work until type(uint32).max | After which the math will eventually overflow
         uint120 scaledEpochEnd = (
@@ -113,7 +113,7 @@ contract BribeInitiative is IInitiative, IBribeInitiative {
         uint240 totalVotes = governance.lqtyToVotes(totalLQTY, scaledEpochEnd, totalAverageTimestamp);
         if (totalVotes != 0) {
             (uint88 lqty, uint120 averageTimestamp) = _decodeLQTYAllocation(lqtyAllocation.value);
-            require(lqty > 0, "BribeInitiative: invalid-prev-lqty");
+            require(lqty > 0, "BribeInitiative: lqty-allocation-zero");
 
             /// @audit Governance Invariant
             assert(averageTimestamp <= scaledEpochEnd);

--- a/test/BribeInitiative.t.sol
+++ b/test/BribeInitiative.t.sol
@@ -857,7 +857,7 @@ contract BribeInitiativeTest is Test {
         epochs[0].epoch = governance.epoch() - 1;
         epochs[0].prevLQTYAllocationEpoch = governance.epoch() - 2;
         epochs[0].prevTotalLQTYAllocationEpoch = governance.epoch() - 2;
-        vm.expectRevert("BribeInitiative: invalid-prev-total-lqty");
+        vm.expectRevert("BribeInitiative: total-lqty-allocation-zero");
         (uint256 boldAmount, uint256 bribeTokenAmount) = bribeInitiative.claimBribes(epochs);
         vm.stopPrank();
 

--- a/test/BribeInitiativeAllocate.t.sol
+++ b/test/BribeInitiativeAllocate.t.sol
@@ -281,7 +281,7 @@ contract BribeInitiativeAllocateTest is Test {
         claimData[0].epoch = 2;
         claimData[0].prevLQTYAllocationEpoch = 2;
         claimData[0].prevTotalLQTYAllocationEpoch = 2;
-        vm.expectRevert("BribeInitiative: invalid-prev-total-lqty");
+        vm.expectRevert("BribeInitiative: total-lqty-allocation-zero");
         (uint256 boldAmount, uint256 bribeTokenAmount) = bribeInitiative.claimBribes(claimData);
         assertEq(boldAmount, 0, "boldAmount nonzero");
         assertEq(bribeTokenAmount, 0, "bribeTokenAmount nonzero");
@@ -708,7 +708,7 @@ contract BribeInitiativeAllocateTest is Test {
         claimData[0].epoch = 1;
         claimData[0].prevLQTYAllocationEpoch = 1;
         claimData[0].prevTotalLQTYAllocationEpoch = 1;
-        vm.expectRevert("BribeInitiative: invalid-prev-lqty");
+        vm.expectRevert("BribeInitiative: lqty-allocation-zero");
         (uint256 boldAmount, uint256 bribeTokenAmount) = bribeInitiative.claimBribes(claimData);
         assertEq(boldAmount, 0);
         assertEq(bribeTokenAmount, 0);


### PR DESCRIPTION
As value now encodes timestamp, it would never be zero, we need to decode and then check.