### PR TITLE
feat: more useful staking events in `Governance`

### DIFF
--- a/src/UserProxy.sol
+++ b/src/UserProxy.sol
@@ -35,12 +35,7 @@ contract UserProxy is IUserProxy {
     function stake(uint256 _amount, address _lqtyFrom, bool _doSendRewards, address _recipient)
         public
         onlyStakingV2
-        returns (
-            uint256 lusdReceived,
-            uint256 lusdSent,
-            uint256 ethReceived,
-            uint256 ethSent
-        )
+        returns (uint256 lusdReceived, uint256 lusdSent, uint256 ethReceived, uint256 ethSent)
     {
         uint256 initialLUSDAmount = lusd.balanceOf(address(this));
         uint256 initialETHAmount = address(this).balance;
@@ -64,16 +59,7 @@ contract UserProxy is IUserProxy {
         PermitParams calldata _permitParams,
         bool _doSendRewards,
         address _recipient
-    )
-        external
-        onlyStakingV2
-        returns (
-            uint256 lusdReceived,
-            uint256 lusdSent,
-            uint256 ethReceived,
-            uint256 ethSent
-        )
-    {
+    ) external onlyStakingV2 returns (uint256 lusdReceived, uint256 lusdSent, uint256 ethReceived, uint256 ethSent) {
         require(_lqtyFrom == _permitParams.owner, "UserProxy: owner-not-sender");
 
         try IERC20Permit(address(lqty)).permit(

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -17,7 +17,7 @@ interface IGovernance {
         uint256 ethReceived,
         uint256 ethSent
     );
-    
+
     event WithdrawLQTY(
         address indexed user,
         address recipient,

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -8,6 +8,14 @@ import {ILQTYStaking} from "./ILQTYStaking.sol";
 import {PermitParams} from "../utils/Types.sol";
 
 interface IGovernance {
+    /// @notice Emitted when a user deposits LQTY
+    /// @param user The account depositing LQTY
+    /// @param rewardRecipient The account receiving the LUSD/ETH rewards earned from staking in V1, if claimed
+    /// @param lqtyAmount The amount of LQTY being deposited
+    /// @return lusdReceived Amount of LUSD tokens received as a side-effect of staking new LQTY
+    /// @return lusdSent Amount of LUSD tokens sent to `rewardRecipient` (may include previously received LUSD)
+    /// @return ethReceived Amount of ETH received as a side-effect of staking new LQTY
+    /// @return ethSent Amount of ETH sent to `rewardRecipient` (may include previously received ETH)
     event DepositLQTY(
         address indexed user,
         address rewardRecipient,
@@ -18,6 +26,15 @@ interface IGovernance {
         uint256 ethSent
     );
 
+    /// @notice Emitted when a user withdraws LQTY or claims V1 staking rewards
+    /// @param user The account withdrawing LQTY or claiming V1 staking rewards
+    /// @param recipient The account receiving the LQTY withdrawn, and if claimed, the LUSD/ETH rewards earned from staking in V1
+    /// @return lqtyReceived Amount of LQTY tokens actually withdrawn (may be lower than the `_lqtyAmount` passed to `withdrawLQTY`)
+    /// @return lqtySent Amount of LQTY tokens sent to `recipient` (may include LQTY sent to the user's proxy from sources other than V1 staking)
+    /// @return lusdReceived Amount of LUSD tokens received as a side-effect of staking new LQTY
+    /// @return lusdSent Amount of LUSD tokens sent to `recipient` (may include previously received LUSD)
+    /// @return ethReceived Amount of ETH received as a side-effect of staking new LQTY
+    /// @return ethSent Amount of ETH sent to `recipient` (may include previously received ETH)
     event WithdrawLQTY(
         address indexed user,
         address recipient,

--- a/src/interfaces/IUserProxy.sol
+++ b/src/interfaces/IUserProxy.sol
@@ -8,16 +8,6 @@ import {ILQTYStaking} from "../interfaces/ILQTYStaking.sol";
 import {PermitParams} from "../utils/Types.sol";
 
 interface IUserProxy {
-    event Stake(uint256 amount, address lqtyFrom);
-    event Unstake(address indexed lqtyRecipient, uint256 lqtyReceived, uint256 lqtySent);
-    event SendRewards(
-        address indexed recipient,
-        uint256 lusdAmountReceived,
-        uint256 lusdAmountSent,
-        uint256 ethAmountReceived,
-        uint256 ethAmountSent
-    );
-
     /// @notice Address of the LQTY token
     /// @return lqty Address of the LQTY token
     function lqty() external view returns (IERC20 lqty);
@@ -37,35 +27,53 @@ interface IUserProxy {
     /// @param _lqtyFrom Address from which to transfer the LQTY tokens
     /// @param _doSendRewards If true, send rewards claimed from LQTY staking
     /// @param _recipient Address to which the tokens should be sent
-    /// @return lusdAmount Amount of LUSD tokens claimed
-    /// @return ethAmount Amount of ETH claimed
+    /// @return lusdReceived Amount of LUSD tokens received as a side-effect of staking new LQTY
+    /// @return lusdSent Amount of LUSD tokens sent to `_recipient` (may include previously received LUSD)
+    /// @return ethReceived Amount of ETH received as a side-effect of staking new LQTY
+    /// @return ethSent Amount of ETH sent to `_recipient` (may include previously received ETH)
     function stake(uint256 _amount, address _lqtyFrom, bool _doSendRewards, address _recipient)
         external
-        returns (uint256 lusdAmount, uint256 ethAmount);
+        returns (uint256 lusdReceived, uint256 lusdSent, uint256 ethReceived, uint256 ethSent);
+
     /// @notice Stakes a given amount of LQTY tokens in the V1 staking contract using a permit
     /// @param _amount Amount of LQTY tokens to stake
     /// @param _lqtyFrom Address from which to transfer the LQTY tokens
     /// @param _permitParams Parameters for the permit data
     /// @param _doSendRewards If true, send rewards claimed from LQTY staking
     /// @param _recipient Address to which the tokens should be sent
-    /// @return lusdAmount Amount of LUSD tokens claimed
-    /// @return ethAmount Amount of ETH claimed
+    /// @return lusdReceived Amount of LUSD tokens received as a side-effect of staking new LQTY
+    /// @return lusdSent Amount of LUSD tokens sent to `_recipient` (may include previously received LUSD)
+    /// @return ethReceived Amount of ETH received as a side-effect of staking new LQTY
+    /// @return ethSent Amount of ETH sent to `_recipient` (may include previously received ETH)
     function stakeViaPermit(
         uint256 _amount,
         address _lqtyFrom,
         PermitParams calldata _permitParams,
         bool _doSendRewards,
         address _recipient
-    ) external returns (uint256 lusdAmount, uint256 ethAmount);
+    ) external returns (uint256 lusdReceived, uint256 lusdSent, uint256 ethReceived, uint256 ethSent);
+
     /// @notice Unstakes a given amount of LQTY tokens from the V1 staking contract and claims the accrued rewards
     /// @param _amount Amount of LQTY tokens to unstake
     /// @param _doSendRewards If true, send rewards claimed from LQTY staking
     /// @param _recipient Address to which the tokens should be sent
-    /// @return lusdAmount Amount of LUSD tokens claimed
-    /// @return ethAmount Amount of ETH claimed
+    /// @return lqtyReceived Amount of LQTY tokens actually unstaked (may be lower than `_amount`)
+    /// @return lqtySent Amount of LQTY tokens sent to `_recipient` (may include LQTY sent to the proxy from sources other than V1 staking)
+    /// @return lusdReceived Amount of LUSD tokens received as a side-effect of staking new LQTY
+    /// @return lusdSent Amount of LUSD tokens claimed (may include previously received LUSD)
+    /// @return ethReceived Amount of ETH received as a side-effect of staking new LQTY
+    /// @return ethSent Amount of ETH claimed (may include previously received ETH)
     function unstake(uint256 _amount, bool _doSendRewards, address _recipient)
         external
-        returns (uint256 lusdAmount, uint256 ethAmount);
+        returns (
+            uint256 lqtyReceived,
+            uint256 lqtySent,
+            uint256 lusdReceived,
+            uint256 lusdSent,
+            uint256 ethReceived,
+            uint256 ethSent
+        );
+
     /// @notice Returns the current amount LQTY staked by a user in the V1 staking contract
     /// @return staked Amount of LQTY tokens staked
     function staked() external view returns (uint88);

--- a/test/UserProxy.t.sol
+++ b/test/UserProxy.t.sol
@@ -117,7 +117,7 @@ abstract contract UserProxyTest is Test, MockStakingV1Deployer {
 
         userProxy.stake(1e18, user, false, address(0));
 
-        (uint256 lusdAmount, uint256 ethAmount) = userProxy.unstake(0, true, user);
+        (,, uint256 lusdAmount,, uint256 ethAmount,) = userProxy.unstake(0, true, user);
         assertEq(lusdAmount, 0);
         assertEq(ethAmount, 0);
 
@@ -130,7 +130,7 @@ abstract contract UserProxyTest is Test, MockStakingV1Deployer {
 
         vm.startPrank(address(userProxyFactory));
 
-        (lusdAmount, ethAmount) = userProxy.unstake(1e18, true, user);
+        (,, lusdAmount,, ethAmount,) = userProxy.unstake(1e18, true, user);
         assertEq(lusdAmount, 1e18);
         assertEq(ethAmount, 1e18);
 


### PR DESCRIPTION
Previously, the details of V1 rewards were emitted by `UserProxy`. This made it harder to query all the information pertaining to the V1 staking that goes through V2, because each user has their own `UserProxy` address.

Plus, the event `WithdrawLQTY` suffered from an issue which has already been fixed for the corresponding event in `UserProxy`, which is that a user can attempt to withdraw more than their V1 staking LQTY balance, in which case the withdrawal gets truncated, but the parameter `withdrawnLQTY` didn't reflect this truncation.

As we don't really need to have duplicate events (`UserProxy` & `Governance`) anyway, we eliminate them from `UserProxy` but expose the details to `Governance`, so that it may emit more useful events of its own.

**Fixes IR-11.**