### PR TITLE
Reset no longer needed on staking & fix underflow

### DIFF
--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -140,11 +140,6 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
     function _increaseUserVoteTrackers(uint256 _lqtyAmount) private returns (UserProxy) {
         require(_lqtyAmount > 0, "Governance: zero-lqty-amount");
 
-        // Assert that we have resetted here
-        // TODO: Remove, as now unecessary
-        UserState memory userState = userStates[msg.sender];
-        require(userState.allocatedLQTY == 0, "Governance: must-be-zero-allocation");
-
         address userProxyAddress = deriveUserProxyAddress(msg.sender);
 
         if (userProxyAddress.code.length == 0) {
@@ -154,10 +149,8 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
         UserProxy userProxy = UserProxy(payable(userProxyAddress));
 
         // update the vote power trackers
-        userState.unallocatedLQTY += _lqtyAmount;
-        userState.unallocatedOffset += block.timestamp * _lqtyAmount;
-
-        userStates[msg.sender] = userState;
+        userStates[msg.sender].unallocatedLQTY += _lqtyAmount;
+        userStates[msg.sender].unallocatedOffset += block.timestamp * _lqtyAmount;
 
         return userProxy;
     }
@@ -203,7 +196,6 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
     function withdrawLQTY(uint256 _lqtyAmount, bool _doSendRewards, address _recipient) public nonReentrant {
         // check that user has reset before changing lqty balance
         UserState storage userState = userStates[msg.sender];
-        require(userState.allocatedLQTY == 0, "Governance: must-allocate-zero");
 
         UserProxy userProxy = UserProxy(payable(deriveUserProxyAddress(msg.sender)));
         require(address(userProxy).code.length != 0, "Governance: user-proxy-not-deployed");

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -194,7 +194,6 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
     }
 
     function withdrawLQTY(uint256 _lqtyAmount, bool _doSendRewards, address _recipient) public nonReentrant {
-        // check that user has reset before changing lqty balance
         UserState storage userState = userStates[msg.sender];
 
         UserProxy userProxy = UserProxy(payable(deriveUserProxyAddress(msg.sender)));

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -200,6 +200,9 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
         UserProxy userProxy = UserProxy(payable(deriveUserProxyAddress(msg.sender)));
         require(address(userProxy).code.length != 0, "Governance: user-proxy-not-deployed");
 
+        // check if user has enough unallocated lqty
+        require(_lqtyAmount <= userState.unallocatedLQTY, "Governance: insufficient-unallocated-lqty");
+
         // Update the offset tracker
         if (_lqtyAmount < userState.unallocatedLQTY) {
             // The offset decrease is proportional to the partial lqty decrease
@@ -212,8 +215,6 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
 
         // Update the user's LQTY tracker
         userState.unallocatedLQTY -= _lqtyAmount;
-
-        userStates[msg.sender] = userState;
 
         (
             uint256 lqtyReceived,

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -562,9 +562,7 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
         return cachedData;
     }
 
-    /// @notice Reset the allocations for the initiatives being passed, must pass all initiatives else it will revert
-    ///     NOTE: If you reset at the last day of the epoch, you won't be able to vote again
-    ///         Use `allocateLQTY` to reset and vote
+    /// @inheritdoc IGovernance
     function resetAllocations(address[] calldata _initiativesToReset, bool checkAll) external nonReentrant {
         _requireNoDuplicates(_initiativesToReset);
         _resetInitiatives(_initiativesToReset);

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -375,16 +375,21 @@ interface IGovernance {
     /// @notice Allocates the user's LQTY to initiatives
     /// @dev The user can only allocate to active initiatives (older than 1 epoch) and has to have enough unallocated
     /// LQTY available, the initiatives listed must be unique, and towards the end of the epoch a user can only maintain or reduce their votes
-    /// @param _resetInitiatives Addresses of the initiatives the caller was previously allocated to, must be reset to prevent desynch of voting power
+    /// @param _initiativesToReset Addresses of the initiatives the caller was previously allocated to, must be reset to prevent desynch of voting power
     /// @param _initiatives Addresses of the initiatives to allocate to, can match or be different from `_resetInitiatives`
-    /// @param _absoluteLQTYVotes Delta LQTY to allocate to the initiatives as votes
-    /// @param absoluteLQTYVetos Delta LQTY to allocate to the initiatives as vetos
+    /// @param _absoluteLQTYVotes LQTY to allocate to the initiatives as votes
+    /// @param _absoluteLQTYVetos LQTY to allocate to the initiatives as vetos
     function allocateLQTY(
-        address[] calldata _resetInitiatives,
+        address[] calldata _initiativesToReset,
         address[] memory _initiatives,
         int256[] memory _absoluteLQTYVotes,
-        int256[] memory absoluteLQTYVetos
+        int256[] memory _absoluteLQTYVetos
     ) external;
+    /// @notice Deallocates the user's LQTY from initiatives
+    /// @param _initiativesToReset Addresses of initiatives to deallocate LQTY from
+    /// @param _checkAll When true, the call will revert if there is still some allocated LQTY left after deallocating
+    ///                  from all the addresses in `_initiativesToReset`
+    function resetAllocations(address[] calldata _initiativesToReset, bool _checkAll) external;
 
     /// @notice Splits accrued funds according to votes received between all initiatives
     /// @param _initiative Addresse of the initiative

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -2287,6 +2287,54 @@ abstract contract GovernanceTest is Test {
         assertEq(votes, currentInitiativePower, "voting power of initiative should not be affected by vetos");
     }
 
+    function test_Vote_Stake_Unvote() external {
+        address[] memory noInitiatives;
+        address[] memory initiatives = new address[](1);
+        int256[] memory noVotes;
+        int256[] memory votes = new int256[](1);
+        int256[] memory vetos = new int256[](1);
+        initiatives[0] = baseInitiative1;
+
+        // Ensure the initial initiatives are active
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        // Have another user vote some on the initiative
+        vm.startPrank(user2);
+        {
+            address userProxy = governance.deriveUserProxyAddress(user2);
+            lqty.approve(userProxy, type(uint256).max);
+
+            governance.depositLQTY(1 ether);
+            votes[0] = 1 ether;
+            governance.allocateLQTY(noInitiatives, initiatives, votes, vetos);
+        }
+        vm.stopPrank();
+
+        (uint256 voteLQTYBefore, uint256 voteOffsetBefore,,,) = governance.initiativeStates(baseInitiative1);
+
+        vm.startPrank(user);
+        {
+            address userProxy = governance.deriveUserProxyAddress(user);
+            lqty.approve(userProxy, type(uint256).max);
+
+            // Vote 1 LQTY
+            governance.depositLQTY(1 ether);
+            votes[0] = 1 ether;
+            governance.allocateLQTY(noInitiatives, initiatives, votes, vetos);
+
+            vm.warp(block.timestamp + 1 days);
+
+            // Increase stake then unvote 1 LQTY
+            governance.depositLQTY(1 ether);
+            governance.allocateLQTY(initiatives, noInitiatives, noVotes, noVotes);
+        }
+        vm.stopPrank();
+
+        (uint256 voteLQTYAfter, uint256 voteOffsetAfter,,,) = governance.initiativeStates(baseInitiative1);
+        assertEqDecimal(voteLQTYAfter, voteLQTYBefore, 18, "voteLQTYAfter != voteLQTYBefore");
+        assertEqDecimal(voteOffsetAfter, voteOffsetBefore, 18, "voteOffsetAfter != voteOffsetBefore");
+    }
+
     function _stakeLQTY(address staker, uint256 amount) internal {
         vm.startPrank(staker);
         address userProxy = governance.deriveUserProxyAddress(staker);

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -998,7 +998,7 @@ abstract contract GovernanceTest is Test {
         // TODO: assertions re: initiative vote + veto offsets
 
         // should revert if the user doesn't have enough unallocated LQTY available
-        vm.expectRevert("Governance: must-allocate-zero");
+        vm.expectRevert("Governance: insufficient-unallocated-lqty");
         governance.withdrawLQTY(1e18);
 
         vm.warp(block.timestamp + EPOCH_DURATION - governance.secondsWithinEpoch() - 1);
@@ -1112,7 +1112,7 @@ abstract contract GovernanceTest is Test {
         // TODO: offset vote + veto assertions
 
         // should revert if the user doesn't have enough unallocated LQTY available
-        vm.expectRevert("Governance: must-allocate-zero");
+        vm.expectRevert("Governance: insufficient-unallocated-lqty");
         governance.withdrawLQTY(1e18);
 
         vm.warp(block.timestamp + EPOCH_DURATION - governance.secondsWithinEpoch() - 1);


### PR DESCRIPTION
Address remaining TODO in `_increaseUserVoteTrackers()` by eliminating reset requirement.
Fixes #108.

Fix possible underflow in `withdrawLQTY()`.
Fixes #109.