### PR TITLE
fix: dust left in `unallocatedOffset` despite allocating all LQTY

### DIFF
--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -780,6 +780,11 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
 
             vars.allocation.atEpoch = vars.currentEpoch;
 
+            // Voting power allocated to initiatives should never be negative, else it might break reward allocation
+            // schemes such as `BribeInitiative` which distribute rewards in proportion to voting power allocated.
+            assert(vars.allocation.voteLQTY * block.timestamp >= vars.allocation.voteOffset);
+            assert(vars.allocation.vetoLQTY * block.timestamp >= vars.allocation.vetoOffset);
+
             lqtyAllocatedByUserToInitiative[msg.sender][initiative] = vars.allocation;
 
             // == USER STATE == //

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -644,6 +644,10 @@ contract Governance is MultiDelegateCall, UserProxyFactory, ReentrancyGuard, Own
         int256[] memory absoluteOffsetVetos = new int256[](_initiatives.length);
 
         // Calculate the offset portions that correspond to each LQTY vote and veto portion
+        // By recalculating `unallocatedLQTY` & `unallocatedOffset` after each step, we ensure that rounding error
+        // doesn't accumulate in `unallocatedOffset`.
+        // However, it should be noted that this makes the exact offset allocations dependent on the ordering of the
+        // `_initiatives` array.
         for (uint256 x; x < _initiatives.length; x++) {
             // Either _absoluteLQTYVotes[x] or _absoluteLQTYVetos[x] is guaranteed to be zero
             (int256[] calldata lqtyAmounts, int256[] memory offsets) = _absoluteLQTYVotes[x] > 0

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -2478,7 +2478,7 @@ abstract contract GovernanceTest is Test {
             // we accrue exactly `initialVotingPower`
             vm.warp(block.timestamp + initialVotingPower);
 
-            governance.depositLQTY(583399417581888701);
+            governance.depositLQTY(1 ether);
 
             address[] memory initiativesToReset; // left empty
             int256[] memory votes = new int256[](initiatives.length);
@@ -2553,7 +2553,7 @@ abstract contract GovernanceTest is Test {
             // we accrue exactly `initialVotingPower`
             vm.warp(block.timestamp + initialVotingPower);
 
-            governance.depositLQTY(583399417581888701);
+            governance.depositLQTY(1 ether);
 
             for (uint256 i = 0; i < numWithdrawals; ++i) {
                 governance.withdrawLQTY(1);


### PR DESCRIPTION
This addresses [**CS-V2Gov-051**: Rounding Error on Offset Calculation](https://github.com/liquity/V2-gov/issues/111).

It should be noted that we're not actually eliminating the rounding error — that's not feasible unless we stop mixing together LQTY staked at different timestamps in `userState` — we're merely feeding it back into `unallocatedOffset` so that there's no "dust" remaining after a total allocation of one's LQTY.

Closes #111.